### PR TITLE
heap: SYS_HEAP_HARDENING BASIC+MODERATE tiers

### DIFF
--- a/zephyr/gale_heap.c
+++ b/zephyr/gale_heap.c
@@ -45,10 +45,13 @@
 #include <zephyr/sys/util.h>
 #include <zephyr/sys/heap_listener.h>
 #include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
 #include <string.h>
 #include "heap.h"
 
 #include "gale_heap.h"
+
+LOG_MODULE_DECLARE(os, CONFIG_KERNEL_LOG_LEVEL);
 
 #ifdef CONFIG_MSAN
 #include <sanitizer/msan_interface.h>
@@ -208,6 +211,28 @@ void sys_heap_free(struct sys_heap *heap, void *mem)
 	}
 	struct z_heap *h = heap->heap;
 	chunkid_t c = mem_to_chunkid(h, mem);
+
+	/*
+	 * SYS_HEAP_HARDENING_BASIC / _MODERATE — upstream lib/heap/heap.c:
+	 * 284-321. Surface upstream's structural checks before the Rust
+	 * decision runs. Use LOG_ERR + k_panic (upstream's pattern) rather
+	 * than __ASSERT: hardening must fire in release builds too, and
+	 * __ASSERT compiles out unless CONFIG_ASSERT=y.
+	 */
+	if (SYS_HEAP_HARDENING_BASIC && !chunk_used(h, c)) {
+		LOG_ERR("heap corruption (double free?) at %p", mem);
+		k_panic();
+	}
+	if (SYS_HEAP_HARDENING_BASIC &&
+	    left_chunk(h, right_chunk(h, c)) != c) {
+		LOG_ERR("heap corruption (buffer overflow?) at %p", mem);
+		k_panic();
+	}
+	if (SYS_HEAP_HARDENING_MODERATE &&
+	    right_chunk(h, left_chunk(h, c)) != c) {
+		LOG_ERR("heap corruption (left neighbor?) at %p", mem);
+		k_panic();
+	}
 
 	/* Extract: chunk state for Rust decision */
 	uint32_t is_used = chunk_used(h, c) ? 1U : 0U;
@@ -411,6 +436,26 @@ static bool inplace_realloc(struct sys_heap *heap, void *ptr, size_t bytes)
 	size_t align_gap = (uint8_t *)ptr - (uint8_t *)chunk_mem(h, c);
 
 	chunksz_t chunks_need = bytes_to_chunksz(h, bytes, align_gap);
+
+	/*
+	 * SYS_HEAP_HARDENING_BASIC / _MODERATE — upstream lib/heap/heap.c:
+	 * 556-569. Same structural checks as sys_heap_free, applied before
+	 * the Rust realloc decision runs. LOG_ERR + k_panic, not __ASSERT.
+	 */
+	if (SYS_HEAP_HARDENING_BASIC && !chunk_used(h, c)) {
+		LOG_ERR("heap corruption (not in use?) at %p", ptr);
+		k_panic();
+	}
+	if (SYS_HEAP_HARDENING_BASIC &&
+	    left_chunk(h, right_chunk(h, c)) != c) {
+		LOG_ERR("heap corruption (buffer overflow?) at %p", ptr);
+		k_panic();
+	}
+	if (SYS_HEAP_HARDENING_MODERATE &&
+	    right_chunk(h, left_chunk(h, c)) != c) {
+		LOG_ERR("heap corruption (left neighbor?) at %p", ptr);
+		k_panic();
+	}
 
 	/* Decide: Rust determines shrink/grow/copy strategy */
 	chunkid_t rc = right_chunk(h, c);


### PR DESCRIPTION
Partial resolution of issue #15.

## Change

Ports upstream Zephyr 4.4's structural heap-hardening checks into `zephyr/gale_heap.c`:
- BASIC tier: double-free + buffer-overflow detection in `sys_heap_free` and `inplace_realloc`
- MODERATE tier: left-neighbor integrity check in both functions
- Uses upstream's diagnostic pattern (`LOG_ERR + k_panic`), not the existing gale-local `__ASSERT`, so hardening fires in release builds too

## Deferred

FULL tier (canary trailers, 8-byte chunk overhead) — drifts gale's Rust HP1 invariant in `src/heap.rs`. Will land after the proof refresh PR per `docs/research/heap-hardening-port-plan.md`.

## Validation (local, real build)

```
west build -b qemu_cortex_m3 -s zephyr/tests/kernel/mem_heap/k_heap_api
  -DZEPHYR_EXTRA_MODULES=gale
  -DOVERLAY_CONFIG=<SEM+HEAP+HARDENING_MODERATE>
```

- FLASH 32752B / RAM 8560B (within existing envelope)
- PROJECT EXECUTION SUCCESSFUL
- All 15 `k_heap_api` tests pass including `test_z_k_heap_double_free`

## What this does NOT do yet

- Does NOT port MODERATE checks in `free_list_{remove,add}_bidx` (upstream heap.c:102,146) or `free_chunk` (line 180) — deferred to keep this PR small.
- Does NOT add a UCA / controller-constraint for the hardening gap in `artifacts/stpa_controllers_ucas.yaml` — orthogonal.

## Test

Full CI runs on merge. Local dev loop uses `scripts/dev-build-test.sh` (landing separately on main).