### PR TITLE
synth: cross-Renode A/B confirms gale's −34.5% delta is real, not simulator-artifactual

### DIFF
--- a/.github/workflows/engine-bench-renode-synth.yml
+++ b/.github/workflows/engine-bench-renode-synth.yml
@@ -87,11 +87,16 @@ jobs:
           . /root/.cargo/env
           rustup target add wasm32-unknown-unknown
 
-      - name: Install synth from pulseengine/synth (feat/synth-relocatable-flag branch)
+      - name: Install synth from pulseengine/synth (fix/synth-i64-locals-and-frame branch)
         run: |
           . /root/.cargo/env
+          # This branch combines:
+          #   - feat/synth-relocatable-flag (PR #83): --relocatable flag
+          #   - fix/synth-i64-locals-and-frame (PR #85): proper i64 local
+          #     storage + stack frame allocation in --no-optimize mode.
+          # Switch to main once both PRs merge.
           cargo install --git https://github.com/pulseengine/synth.git \
-                        --branch feat/synth-relocatable-flag \
+                        --branch fix/synth-i64-locals-and-frame \
                         synth-cli \
                         --force
           synth --version

--- a/.github/workflows/engine-bench-renode-synth.yml
+++ b/.github/workflows/engine-bench-renode-synth.yml
@@ -92,7 +92,7 @@ jobs:
           . /root/.cargo/env
           cargo install --git https://github.com/pulseengine/synth.git \
                         --branch feat/synth-relocatable-flag \
-                        --path crates/synth-cli \
+                        synth-cli \
                         --force
           synth --version
 
@@ -108,7 +108,7 @@ jobs:
           # rustc -> synth directly.
           . /root/.cargo/env
           cargo install --git https://github.com/pulseengine/loom.git \
-                        --path loom-cli \
+                        loom-cli \
                         --force
           loom --version
 

--- a/.github/workflows/engine-bench-renode-synth.yml
+++ b/.github/workflows/engine-bench-renode-synth.yml
@@ -39,6 +39,9 @@ name: Engine bench long under gale-via-synth (Renode)
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - experiment/gale-via-synth
 
 permissions:
   contents: read

--- a/.github/workflows/engine-bench-renode-synth.yml
+++ b/.github/workflows/engine-bench-renode-synth.yml
@@ -112,10 +112,11 @@ jobs:
           # found, build skips the optimization step and falls through to
           # rustc -> synth directly.
           . /root/.cargo/env
-          cargo install --git https://github.com/pulseengine/loom.git \
-                        loom-cli \
-                        --force
-          loom --version
+          # loom DELIBERATELY OMITTED — investigating whether loom miscompiles
+          # gale_k_sem_give_decide in a way that drops the WakeThread/Increment
+          # distinction. See cycle-analysis investigation. CMakeLists ferret-skips
+          # loom if find_program fails.
+          echo "loom install skipped (cycle-analysis run)"
 
       - name: West init + update + Renode + SDK
         run: |

--- a/.github/workflows/engine-bench-renode-synth.yml
+++ b/.github/workflows/engine-bench-renode-synth.yml
@@ -22,8 +22,14 @@
 # alongside so we get same-CI cycle deltas.
 #
 # Sample count: 10,000 per build (long sweep), matching the LTO workflow.
-# Runtime ~15-25 min per build, ~50-60 min total for both Renode runs.
-# timeout-minutes: 120 covers it with margin.
+# Runtime ~15-25 min per build, ~50-60 min total for both Renode runs
+# under 1.16.0, plus ~50-60 min for the nightly A/B reruns.
+# timeout-minutes: 240 covers all four Renode runs with margin.
+#
+# Cycle-model A/B: the container ships Renode 1.16.0. The same two ELFs
+# are also run under Renode nightly to attribute the observed gale-vs-
+# baseline cycle delta — see the "Render nightly comparison" step for
+# the three controls (a/b/c).
 #
 # Note on the synth source: the relocatable-flag support lives on the
 # feat/synth-relocatable-flag branch (PR
@@ -57,7 +63,7 @@ defaults:
 jobs:
   long-run-synth:
     runs-on: ubuntu-22.04
-    timeout-minutes: 120
+    timeout-minutes: 240
     container:
       image: ghcr.io/zephyrproject-rtos/ci:v0.29.0
       options: --user root
@@ -142,6 +148,24 @@ jobs:
           echo "ZEPHYR_SDK_INSTALL_DIR=${SDK_DIR}" >> "$GITHUB_ENV"
           echo "SDK: ${SDK_DIR}"
 
+      - name: Install Renode nightly (parallel install, for cycle-model A/B)
+        run: |
+          # Container ships Renode 1.16.0 (pinned in zephyr docker-image
+          # Dockerfile.base across v0.28.x → v0.29.2). The unexplained
+          # gale-via-synth -34.5% cycle delta might be partly an artifact
+          # of the 1.16.0 Cortex-M cycle model (Thumb-2 dispatch / SP[1:0]
+          # handling were touched in 1.16.1). We run the same two ELFs
+          # under nightly Renode as a control: if the delta moves, we've
+          # fingerprinted Renode model drift; if it doesn't, we've ruled
+          # the model out and the gap is in the actual instruction stream.
+          mkdir -p /opt/renode-nightly
+          curl -sSL https://builds.renode.io/renode-latest.linux-portable-dotnet.tar.gz \
+            | tar xz -C /opt/renode-nightly --strip-components=1
+          /opt/renode-nightly/renode --version
+          # Robot framework deps for renode-test — same set as the bundled
+          # 1.16.0 install but for the nightly tree.
+          pip3 install -r /opt/renode-nightly/tests/requirements.txt --no-cache-dir
+
       - name: Build baseline (GCC -Os, no Gale, long sweep)
         env:
           ZEPHYR_BASE: ${{ github.workspace }}/zephyr-workspace/zephyr
@@ -187,6 +211,33 @@ jobs:
           cd "$GITHUB_WORKSPACE/renode-gale-synth"
           renode-test "$GALE_ROOT/benches/engine_control/renode/engine_stm32f4.robot"
 
+      - name: Run baseline in Renode (nightly)
+        env:
+          ELF:           /tmp/engine-baseline-long/zephyr/zephyr.elf
+          BENCH_CSV_OUT: /tmp/engine-baseline-long/output-nightly.csv
+          GALE_ROOT:     ${{ github.workspace }}/gale
+        run: |
+          # Same ELF as the 1.16.0 baseline run; only the simulator
+          # changes. PATH override puts nightly's renode/renode-test
+          # in front of the container's bundled 1.16.0.
+          export PATH="/opt/renode-nightly:$PATH"
+          renode --version
+          mkdir -p "$GITHUB_WORKSPACE/renode-baseline-nightly"
+          cd "$GITHUB_WORKSPACE/renode-baseline-nightly"
+          renode-test "$GALE_ROOT/benches/engine_control/renode/engine_stm32f4.robot"
+
+      - name: Run gale-via-synth in Renode (nightly)
+        env:
+          ELF:           /tmp/engine-synth-long/zephyr/zephyr.elf
+          BENCH_CSV_OUT: /tmp/engine-synth-long/output-nightly.csv
+          GALE_ROOT:     ${{ github.workspace }}/gale
+        run: |
+          export PATH="/opt/renode-nightly:$PATH"
+          renode --version
+          mkdir -p "$GITHUB_WORKSPACE/renode-gale-synth-nightly"
+          cd "$GITHUB_WORKSPACE/renode-gale-synth-nightly"
+          renode-test "$GALE_ROOT/benches/engine_control/renode/engine_stm32f4.robot"
+
       - name: Tag events with run-id for analyzer
         run: |
           # Same shape as engine-bench-renode.yml.
@@ -209,6 +260,41 @@ jobs:
           python3 - <<'PY' \
               /tmp/engine-synth-long/output.csv gale \
               > /tmp/engine-synth-long/events.csv
+          import sys
+          raw_path, variant = sys.argv[1], sys.argv[2]
+          with open(raw_path, 'rt', errors='replace') as f:
+              for line in f:
+                  line = line.rstrip('\r\n')
+                  if line.startswith('E,'):
+                      print(f"R1,{variant},{line}")
+                  elif line.startswith(('drops,', 'samples,', 'build,',
+                                        'cycles_per_sec,', 'target_samples,')):
+                      print(f"M,R1,{variant},{line}")
+                  elif line == '=== END ===':
+                      print(f"M,R1,{variant},END")
+          PY
+          # Nightly Renode outputs — same R1 tagging (single run each),
+          # written to events-nightly.csv so the headline 1.16.0 comparison
+          # is undisturbed.
+          python3 - <<'PY' \
+              /tmp/engine-baseline-long/output-nightly.csv baseline \
+              > /tmp/engine-baseline-long/events-nightly.csv
+          import sys
+          raw_path, variant = sys.argv[1], sys.argv[2]
+          with open(raw_path, 'rt', errors='replace') as f:
+              for line in f:
+                  line = line.rstrip('\r\n')
+                  if line.startswith('E,'):
+                      print(f"R1,{variant},{line}")
+                  elif line.startswith(('drops,', 'samples,', 'build,',
+                                        'cycles_per_sec,', 'target_samples,')):
+                      print(f"M,R1,{variant},{line}")
+                  elif line == '=== END ===':
+                      print(f"M,R1,{variant},END")
+          PY
+          python3 - <<'PY' \
+              /tmp/engine-synth-long/output-nightly.csv gale \
+              > /tmp/engine-synth-long/events-nightly.csv
           import sys
           raw_path, variant = sys.argv[1], sys.argv[2]
           with open(raw_path, 'rt', errors='replace') as f:
@@ -245,6 +331,76 @@ jobs:
             cat /tmp/engine-comparison-synth.md
           } >> "$GITHUB_STEP_SUMMARY"
 
+      - name: Render nightly comparison + cross-Renode model-drift check
+        env:
+          GALE_ROOT: ${{ github.workspace }}/gale
+        run: |
+          # Three additional comparisons to attribute the observed delta:
+          #   (a) baseline vs gale, BOTH under nightly Renode
+          #       — does the gale delta change when the cycle model changes?
+          #   (b) baseline_1.16.0 vs baseline_nightly (same ELF)
+          #       — control: how much does the cycle model alone shift cycles
+          #         on identical instructions?
+          #   (c) gale_1.16.0 vs gale_nightly (same ELF)
+          #       — does the model shift gale's instructions more than the
+          #         baseline's? If yes, gale's instruction mix is mis-scored
+          #         by the older model and the delta is partly artifactual.
+          #
+          # analyze.py's --baseline / --gale flags are just column labels —
+          # the comparison itself is symmetric, so we (ab)use them for the
+          # cross-Renode controls.
+          python3 "$GALE_ROOT/benches/engine_control/analyze.py" \
+            --baseline /tmp/engine-baseline-long/events-nightly.csv \
+            --gale     /tmp/engine-synth-long/events-nightly.csv \
+            --runs 1 \
+            > /tmp/engine-comparison-synth-nightly.md || true
+          python3 "$GALE_ROOT/benches/engine_control/analyze.py" \
+            --baseline /tmp/engine-baseline-long/events.csv \
+            --gale     /tmp/engine-baseline-long/events-nightly.csv \
+            --runs 1 \
+            > /tmp/engine-cross-renode-baseline.md || true
+          python3 "$GALE_ROOT/benches/engine_control/analyze.py" \
+            --baseline /tmp/engine-synth-long/events.csv \
+            --gale     /tmp/engine-synth-long/events-nightly.csv \
+            --runs 1 \
+            > /tmp/engine-cross-renode-gale.md || true
+          {
+            echo ''
+            echo '## Cycle-model A/B — Renode 1.16.0 vs nightly'
+            echo ''
+            echo 'The headline comparison above was run under Renode 1.16.0'
+            echo '(pinned in the zephyr docker-image). The same two ELFs are'
+            echo 'also run under Renode nightly to test whether the observed'
+            echo 'gale-via-synth delta is partly a cycle-model artifact.'
+            echo ''
+            echo '### (a) baseline vs gale, both under nightly Renode'
+            echo ''
+            echo 'If the gale-vs-baseline gap looks similar to the 1.16.0 run,'
+            echo 'the delta is real (in the instruction stream). If it shrinks'
+            echo 'or vanishes, the 1.16.0 cycle model was over-counting one of'
+            echo 'the two paths.'
+            echo ''
+            cat /tmp/engine-comparison-synth-nightly.md
+            echo ''
+            echo '### (b) baseline ELF: 1.16.0 vs nightly (same .elf)'
+            echo ''
+            echo 'Control. Same compiled bytes, different simulator. Any nonzero'
+            echo 'delta is pure cycle-model drift. "baseline" column = 1.16.0,'
+            echo '"gale" column = nightly.'
+            echo ''
+            cat /tmp/engine-cross-renode-baseline.md
+            echo ''
+            echo '### (c) gale ELF: 1.16.0 vs nightly (same .elf)'
+            echo ''
+            echo 'Same control on the gale path. If (c) shows a larger drift'
+            echo 'than (b), the 1.16.0 model is mis-scoring gale-specific'
+            echo 'instructions (Thumb-2 dispatch / SP[1:0] / FPU-disabled were'
+            echo 'all touched in 1.16.1). "baseline" column = 1.16.0,'
+            echo '"gale" column = nightly.'
+            echo ''
+            cat /tmp/engine-cross-renode-gale.md
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Upload event streams + report
         if: always()
         uses: actions/upload-artifact@v4
@@ -255,7 +411,16 @@ jobs:
             /tmp/engine-synth-long/output.csv
             /tmp/engine-baseline-long/events.csv
             /tmp/engine-synth-long/events.csv
+            /tmp/engine-baseline-long/output-nightly.csv
+            /tmp/engine-synth-long/output-nightly.csv
+            /tmp/engine-baseline-long/events-nightly.csv
+            /tmp/engine-synth-long/events-nightly.csv
             renode-baseline/
             renode-gale-synth/
+            renode-baseline-nightly/
+            renode-gale-synth-nightly/
             /tmp/engine-comparison-synth.md
+            /tmp/engine-comparison-synth-nightly.md
+            /tmp/engine-cross-renode-baseline.md
+            /tmp/engine-cross-renode-gale.md
           if-no-files-found: ignore

--- a/.github/workflows/engine-bench-renode-synth.yml
+++ b/.github/workflows/engine-bench-renode-synth.yml
@@ -93,6 +93,22 @@ jobs:
                         --force
           synth --version
 
+      - name: Install wasm-opt (Binaryen) and loom (pulseengine/loom)
+        run: |
+          # wasm-opt: Binaryen size optimizer. apt's binaryen package
+          # provides the wasm-opt binary on Ubuntu 22.04.
+          apt-get update && apt-get install -y binaryen
+          wasm-opt --version
+          # loom: formally-verified WASM optimizer (each pass proved sound).
+          # Optional in the gale CMakeLists pipeline — if neither tool is
+          # found, build skips the optimization step and falls through to
+          # rustc -> synth directly.
+          . /root/.cargo/env
+          cargo install --git https://github.com/pulseengine/loom.git \
+                        --path loom-cli \
+                        --force
+          loom --version
+
       - name: West init + update + Renode + SDK
         run: |
           pip3 install west robotframework

--- a/.github/workflows/engine-bench-renode-synth.yml
+++ b/.github/workflows/engine-bench-renode-synth.yml
@@ -22,14 +22,20 @@
 # alongside so we get same-CI cycle deltas.
 #
 # Sample count: 10,000 per build (long sweep), matching the LTO workflow.
-# Runtime ~15-25 min per build, ~50-60 min total for both Renode runs
-# under 1.16.0, plus ~50-60 min for the nightly A/B reruns.
-# timeout-minutes: 240 covers all four Renode runs with margin.
+# Runtime ~15-25 min per build x 3 builds, ~10-15 min per Renode run x 5
+# (baseline 1.16.0, synth 1.16.0, rustc-direct 1.16.0, baseline nightly,
+# synth nightly). timeout-minutes: 300 covers it with margin.
 #
-# Cycle-model A/B: the container ships Renode 1.16.0. The same two ELFs
-# are also run under Renode nightly to attribute the observed gale-vs-
-# baseline cycle delta — see the "Render nightly comparison" step for
-# the three controls (a/b/c).
+# Cycle-model A/B (controls a/b/c): the container ships Renode 1.16.0.
+# The same baseline + synth ELFs are also run under Renode nightly to
+# attribute the observed gale-vs-baseline cycle delta — see the "Render
+# nightly comparison" step.
+#
+# Synth correctness control (audit P7, DO-330 §6.1.4): a third gale
+# build via rustc-direct (no synth in the chain) is run alongside under
+# 1.16.0. If synth's handoff median agrees with rustc-direct's within
+# ~3%, the synth-emitted ELF is a faithful Cortex-M codegen of the same
+# Rust source. See the "Render synth-vs-rustc-direct" step.
 #
 # Note on the synth source: the relocatable-flag support lives on the
 # feat/synth-relocatable-flag branch (PR
@@ -63,7 +69,7 @@ defaults:
 jobs:
   long-run-synth:
     runs-on: ubuntu-22.04
-    timeout-minutes: 240
+    timeout-minutes: 300
     container:
       image: ghcr.io/zephyrproject-rtos/ci:v0.29.0
       options: --user root
@@ -159,8 +165,14 @@ jobs:
           # fingerprinted Renode model drift; if it doesn't, we've ruled
           # the model out and the gap is in the actual instruction stream.
           mkdir -p /opt/renode-nightly
-          curl -sSL https://builds.renode.io/renode-latest.linux-portable-dotnet.tar.gz \
-            | tar xz -C /opt/renode-nightly --strip-components=1
+          # Download to a known path so we can sha256 it for the
+          # build manifest (D6) — without this, the same "nightly"
+          # arm cannot be reproduced 6 months from now.
+          curl -sSL -o /tmp/renode-nightly.tgz \
+            https://builds.renode.io/renode-latest.linux-portable-dotnet.tar.gz
+          sha256sum /tmp/renode-nightly.tgz
+          tar xzf /tmp/renode-nightly.tgz -C /opt/renode-nightly \
+            --strip-components=1
           /opt/renode-nightly/renode --version
           # Robot framework deps for renode-test — same set as the bundled
           # 1.16.0 install but for the nightly tree.
@@ -191,6 +203,30 @@ jobs:
               -DGALE_USE_SYNTH=ON \
               -DENGINE_BENCH_SWEEP=long
 
+      - name: Build gale (via rustc-direct, long sweep) — synth correctness control
+        env:
+          ZEPHYR_BASE: ${{ github.workspace }}/zephyr-workspace/zephyr
+          GALE_ROOT:   ${{ github.workspace }}/gale
+        run: |
+          # Cross-check arm: build the same gale-ffi crate with rustc
+          # targeting Cortex-M directly (no synth in the chain). The
+          # synth-emitted gale ELF should produce handoff/algo cycle
+          # counts within ~3% of this rustc-direct ELF — if they
+          # diverge, synth's codegen has a correctness or efficiency
+          # bug that the bench's nominal A/B can't catch on its own.
+          # Per audit P7 (tool qualification): synth is a research
+          # compiler with no upstream qualification path; this third
+          # arm is the cheapest possible "tool error mitigation" in
+          # the DO-330 §6.1.4 sense — a redundant computation by a
+          # much more battle-tested tool with the same input contract.
+          . /root/.cargo/env
+          west build -b stm32f4_disco -d /tmp/engine-rustc-long \
+            -s "$GALE_ROOT/benches/engine_control" \
+            -- \
+              -DZEPHYR_EXTRA_MODULES="$GALE_ROOT" \
+              -DOVERLAY_CONFIG="$GALE_ROOT/benches/engine_control/prj-gale.conf" \
+              -DENGINE_BENCH_SWEEP=long
+
       - name: Run baseline in Renode
         env:
           ELF:           /tmp/engine-baseline-long/zephyr/zephyr.elf
@@ -209,6 +245,24 @@ jobs:
         run: |
           mkdir -p "$GITHUB_WORKSPACE/renode-gale-synth"
           cd "$GITHUB_WORKSPACE/renode-gale-synth"
+          renode-test "$GALE_ROOT/benches/engine_control/renode/engine_stm32f4.robot"
+
+      - name: Run gale-via-rustc-direct in Renode (synth correctness control)
+        env:
+          ELF:           /tmp/engine-rustc-long/zephyr/zephyr.elf
+          BENCH_CSV_OUT: /tmp/engine-rustc-long/output.csv
+          GALE_ROOT:     ${{ github.workspace }}/gale
+        run: |
+          # Same Renode 1.16.0 as the headline two arms — the question
+          # this run answers is "does synth's Cortex-M codegen produce
+          # the same cycle counts as rustc-direct on the same Rust
+          # source?" — *not* a cycle-model question. We don't run this
+          # ELF under nightly Renode because the cycle-model A/B
+          # already established on baseline + gale-via-synth that
+          # 1.16.0 ≡ nightly within rounding (see step "Render nightly
+          # comparison" output (b) and (c)).
+          mkdir -p "$GITHUB_WORKSPACE/renode-gale-rustc"
+          cd "$GITHUB_WORKSPACE/renode-gale-rustc"
           renode-test "$GALE_ROOT/benches/engine_control/renode/engine_stm32f4.robot"
 
       - name: Run baseline in Renode (nightly)
@@ -295,6 +349,26 @@ jobs:
           python3 - <<'PY' \
               /tmp/engine-synth-long/output-nightly.csv gale \
               > /tmp/engine-synth-long/events-nightly.csv
+          import sys
+          raw_path, variant = sys.argv[1], sys.argv[2]
+          with open(raw_path, 'rt', errors='replace') as f:
+              for line in f:
+                  line = line.rstrip('\r\n')
+                  if line.startswith('E,'):
+                      print(f"R1,{variant},{line}")
+                  elif line.startswith(('drops,', 'samples,', 'build,',
+                                        'cycles_per_sec,', 'target_samples,')):
+                      print(f"M,R1,{variant},{line}")
+                  elif line == '=== END ===':
+                      print(f"M,R1,{variant},END")
+          PY
+          # Rustc-direct cross-check arm. Same R1 tag — analyze.py
+          # treats it as just another "gale" variant for column
+          # purposes; the cross-check report compares synth vs rustc
+          # directly (without baseline).
+          python3 - <<'PY' \
+              /tmp/engine-rustc-long/output.csv gale \
+              > /tmp/engine-rustc-long/events.csv
           import sys
           raw_path, variant = sys.argv[1], sys.argv[2]
           with open(raw_path, 'rt', errors='replace') as f:
@@ -401,6 +475,115 @@ jobs:
             cat /tmp/engine-cross-renode-gale.md
           } >> "$GITHUB_STEP_SUMMARY"
 
+      - name: Render synth-vs-rustc-direct cross-check (tool-qualification control)
+        env:
+          GALE_ROOT: ${{ github.workspace }}/gale
+        run: |
+          # Per audit P7 (tool qualification, DO-330 §6.1.4):
+          # synth is a research compiler with no upstream qualification
+          # path. The cycle-model A/B (steps a/b/c above) ruled out the
+          # simulator as the source of the delta, but a synth miscompile
+          # that produces semantically-different-but-not-crashing code
+          # (e.g. regalloc that elides a register-spill, or i64 split that
+          # aliases the wrong half) would still report cycle counts
+          # downstream. The rustc-direct ELF runs the SAME Rust source
+          # through a much more battle-tested compiler; if the two
+          # disagree on handoff median by more than a few percent, the
+          # delta is partly synth-specific and the publication-bound
+          # number must include the rustc-direct comparison too.
+          python3 "$GALE_ROOT/benches/engine_control/analyze.py" \
+            --baseline /tmp/engine-synth-long/events.csv \
+            --gale     /tmp/engine-rustc-long/events.csv \
+            --runs 1 \
+            > /tmp/engine-synth-vs-rustc.md || true
+          {
+            echo ''
+            echo '## Synth correctness — gale-via-synth vs gale-via-rustc-direct'
+            echo ''
+            echo 'Both ELFs are gale-with-the-same-source; "baseline" column is'
+            echo 'synth-emitted, "gale" column is rustc-direct. A tight median'
+            echo 'agreement (Δ < ~3%) confirms synth is a faithful Cortex-M code'
+            echo 'generator for this Rust source. Larger disagreement on `handoff`'
+            echo 'or `algo` indicates a synth-specific codegen artifact and the'
+            echo 'headline comparison should disclose both numbers.'
+            echo ''
+            cat /tmp/engine-synth-vs-rustc.md
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Compose build manifest (single point of provenance)
+        if: always()
+        env:
+          GALE_ROOT: ${{ github.workspace }}/gale
+        run: |
+          # Per audit P9 (configuration management): a reader who downloads
+          # the artifact bundle 6 months from now should be able to identify
+          # exactly which Renode, synth, rustc, wasm-opt, Zephyr, and SDK
+          # produced these numbers. Without this manifest, "I ran exactly
+          # this configuration" reduces to "trust the gale_sha and hope
+          # nothing else moved" — which is wrong, because every pinned
+          # input in this workflow is a branch tip or a moving tag.
+          mkdir -p /tmp/manifest
+          . /root/.cargo/env || true
+          {
+            echo "# Gale bench manifest — single point of provenance"
+            echo "# Produced by .github/workflows/engine-bench-renode-synth.yml"
+            echo "produced_at:           $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+            echo "run_id:                ${{ github.run_id }}"
+            echo "run_attempt:           ${{ github.run_attempt }}"
+            echo "gale_sha:              ${{ github.sha }}"
+            echo "gale_ref:              ${{ github.ref }}"
+            echo "container:             ghcr.io/zephyrproject-rtos/ci:v0.29.0"
+            echo "runner:                $(uname -srm)"
+            echo "---"
+            echo "# Toolchain"
+            echo "rustc:                 $(rustc --version 2>&1 | head -1)"
+            echo "cargo:                 $(cargo --version 2>&1 | head -1)"
+            echo "wasm-opt:              $(wasm-opt --version 2>&1 | head -1)"
+            echo "synth:                 $(synth --version 2>&1 | head -1)"
+            echo "west:                  $(west --version 2>&1 | head -1)"
+            echo "robotframework:        $(pip3 show robotframework 2>&1 \
+                                          | awk '/^Version/ {print $2}')"
+            echo "sdk_dir:               ${ZEPHYR_SDK_INSTALL_DIR:-unknown}"
+            echo "---"
+            echo "# Renode"
+            echo "renode_1.16.0:         $(renode --version 2>&1 | head -1)"
+            echo "renode_nightly:        $(/opt/renode-nightly/renode --version 2>&1 | head -1)"
+            if [ -f /tmp/renode-nightly.tgz ]; then
+              echo "renode_nightly_sha256: $(sha256sum /tmp/renode-nightly.tgz | awk '{print $1}')"
+              echo "renode_nightly_bytes:  $(stat -c '%s' /tmp/renode-nightly.tgz 2>/dev/null \
+                                             || stat -f '%z' /tmp/renode-nightly.tgz)"
+            fi
+            echo "---"
+            echo "# West manifest (Zephyr fork + modules at landed sha)"
+            ( cd "${GITHUB_WORKSPACE}/zephyr-workspace" \
+              && west list --format='{name}: {revision}' 2>&1 ) \
+              | sed 's/^/  /' || echo "  (west list unavailable)"
+            echo "---"
+            echo "# Built ELFs (sha256, path)"
+            for elf in /tmp/engine-baseline-long/zephyr/zephyr.elf \
+                       /tmp/engine-synth-long/zephyr/zephyr.elf \
+                       /tmp/engine-rustc-long/zephyr/zephyr.elf; do
+              if [ -f "$elf" ]; then
+                printf "  %s  %s\n" \
+                  "$(sha256sum "$elf" | awk '{print $1}')" "$elf"
+              fi
+            done
+            echo "---"
+            echo "# CSV outputs (sha256, bytes, path)"
+            for csv in /tmp/engine-baseline-long/output.csv \
+                       /tmp/engine-synth-long/output.csv \
+                       /tmp/engine-rustc-long/output.csv \
+                       /tmp/engine-baseline-long/output-nightly.csv \
+                       /tmp/engine-synth-long/output-nightly.csv; do
+              if [ -f "$csv" ]; then
+                bytes=$(stat -c '%s' "$csv" 2>/dev/null || stat -f '%z' "$csv")
+                printf "  %s  %s  %s\n" \
+                  "$(sha256sum "$csv" | awk '{print $1}')" \
+                  "$bytes" "$csv"
+              fi
+            done
+          } | tee /tmp/manifest.txt
+
       - name: Upload event streams + report
         if: always()
         uses: actions/upload-artifact@v4
@@ -409,18 +592,26 @@ jobs:
           path: |
             /tmp/engine-baseline-long/output.csv
             /tmp/engine-synth-long/output.csv
+            /tmp/engine-rustc-long/output.csv
             /tmp/engine-baseline-long/events.csv
             /tmp/engine-synth-long/events.csv
+            /tmp/engine-rustc-long/events.csv
             /tmp/engine-baseline-long/output-nightly.csv
             /tmp/engine-synth-long/output-nightly.csv
             /tmp/engine-baseline-long/events-nightly.csv
             /tmp/engine-synth-long/events-nightly.csv
             renode-baseline/
             renode-gale-synth/
+            renode-gale-rustc/
             renode-baseline-nightly/
             renode-gale-synth-nightly/
             /tmp/engine-comparison-synth.md
             /tmp/engine-comparison-synth-nightly.md
             /tmp/engine-cross-renode-baseline.md
             /tmp/engine-cross-renode-gale.md
+            /tmp/engine-synth-vs-rustc.md
+            /tmp/manifest.txt
+            /tmp/engine-baseline-long/zephyr/zephyr.elf
+            /tmp/engine-synth-long/zephyr/zephyr.elf
+            /tmp/engine-rustc-long/zephyr/zephyr.elf
           if-no-files-found: ignore

--- a/.github/workflows/engine-bench-renode-synth.yml
+++ b/.github/workflows/engine-bench-renode-synth.yml
@@ -1,0 +1,236 @@
+# Engine-control benchmark — Renode long run UNDER gale-via-synth.
+#
+# 4th-variant follow-up to the cross-language LTO experiment
+# (see engine-bench-renode-lto.yml and the published post at
+# https://pulseengine.eu/blog/cross-language-lto-three-quiet-barriers/).
+#
+# That post compared three builds on stm32f4_disco (7,750 samples each,
+# p<1e-100 across 13 RPM steps): GCC baseline, GCC + Gale (rustc-direct),
+# LLVM + LTO + Gale. This workflow adds the 4th variant: gale-ffi compiled
+# to wasm32-unknown-unknown, then run through pulseengine/synth to produce
+# a Cortex-M ET_REL relocatable, wrapped into libgale_ffi.a, and linked
+# into the engine bench.
+#
+# Build pipeline for the synth variant:
+#   cargo rustc --target wasm32-unknown-unknown
+#     -> synth (wasm -> Cortex-M ET_REL relocatable)
+#     -> ar (wrap into libgale_ffi.a)
+#     -> linked into the engine bench ELF
+#
+# This is gated by the GALE_USE_SYNTH=ON CMake option on the
+# experiment/gale-via-synth branch. Baseline (GCC -Os, no Gale) is built
+# alongside so we get same-CI cycle deltas.
+#
+# Sample count: 10,000 per build (long sweep), matching the LTO workflow.
+# Runtime ~15-25 min per build, ~50-60 min total for both Renode runs.
+# timeout-minutes: 120 covers it with margin.
+#
+# Note on the synth source: the relocatable-flag support lives on the
+# feat/synth-relocatable-flag branch (PR
+# https://github.com/pulseengine/synth/pull/83). Once that PR merges,
+# switch the cargo install --branch arg to main.
+#
+# Security: this workflow uses no untrusted GitHub event inputs
+# (issue title, PR body, commit message) in shell commands. Only
+# github.workspace (filesystem path) and github.ref (concurrency key)
+# are referenced, both safe contexts.
+
+name: Engine bench long under gale-via-synth (Renode)
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: engine-bench-renode-synth-${{ github.ref }}
+  cancel-in-progress: false
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  long-run-synth:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 120
+    container:
+      image: ghcr.io/zephyrproject-rtos/ci:v0.29.0
+      options: --user root
+    env:
+      HOME: /root
+      DOCKER_CONFIG: /tmp/.docker
+    steps:
+      - name: Checkout Gale
+        uses: actions/checkout@v4
+        with:
+          path: gale
+
+      - name: Install Rust + ARM targets
+        run: |
+          apt-get update -qq && apt-get install -y -qq curl > /dev/null 2>&1
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+            | sh -s -- -y --default-toolchain stable
+          . /root/.cargo/env
+          # stm32f4_disco is Cortex-M4F. Engine bench keeps CONFIG_FPU
+          # off (no float in the ISR path) so cargo selects the soft-
+          # float target. Install both for safety.
+          rustup target add thumbv7em-none-eabi
+          rustup target add thumbv7em-none-eabihf
+
+      - name: Install Rust wasm32-unknown-unknown target
+        run: |
+          . /root/.cargo/env
+          rustup target add wasm32-unknown-unknown
+
+      - name: Install synth from pulseengine/synth (feat/synth-relocatable-flag branch)
+        run: |
+          . /root/.cargo/env
+          cargo install --git https://github.com/pulseengine/synth.git \
+                        --branch feat/synth-relocatable-flag \
+                        --path crates/synth-cli \
+                        --force
+          synth --version
+
+      - name: West init + update + Renode + SDK
+        run: |
+          pip3 install west robotframework
+          west init -m https://github.com/pulseengine/zephyr.git \
+            --mr gale/sem-replacement zephyr-workspace
+          cd zephyr-workspace
+          west update --narrow -o=--depth=1
+          for attempt in 1 2 3; do
+            west sdk install -t arm-zephyr-eabi && break || sleep 5
+          done
+
+      - name: Setup SDK paths
+        run: |
+          SDK_DIR=$(find /root -maxdepth 1 -name 'zephyr-sdk-*' -type d | head -1)
+          [ -z "${SDK_DIR}" ] && SDK_DIR=$(find /opt -maxdepth 2 -name 'zephyr-sdk-*' -type d | head -1)
+          if [ -d "${SDK_DIR}/gnu/arm-zephyr-eabi/bin" ]; then
+            ARM_BIN="${SDK_DIR}/gnu/arm-zephyr-eabi"
+          else
+            ARM_BIN="${SDK_DIR}/arm-zephyr-eabi"
+          fi
+          echo "${ARM_BIN}/bin" >> "$GITHUB_PATH"
+          echo "ZEPHYR_SDK_INSTALL_DIR=${SDK_DIR}" >> "$GITHUB_ENV"
+          echo "SDK: ${SDK_DIR}"
+
+      - name: Build baseline (GCC -Os, no Gale, long sweep)
+        env:
+          ZEPHYR_BASE: ${{ github.workspace }}/zephyr-workspace/zephyr
+          GALE_ROOT:   ${{ github.workspace }}/gale
+        run: |
+          . /root/.cargo/env
+          west build -b stm32f4_disco -d /tmp/engine-baseline-long \
+            -s "$GALE_ROOT/benches/engine_control" \
+            -- \
+              -DENGINE_BENCH_SWEEP=long
+
+      - name: Build gale (via synth, long sweep)
+        env:
+          ZEPHYR_BASE: ${{ github.workspace }}/zephyr-workspace/zephyr
+          GALE_ROOT:   ${{ github.workspace }}/gale
+        run: |
+          . /root/.cargo/env
+          west build -b stm32f4_disco -d /tmp/engine-synth-long \
+            -s "$GALE_ROOT/benches/engine_control" \
+            -- \
+              -DZEPHYR_EXTRA_MODULES="$GALE_ROOT" \
+              -DOVERLAY_CONFIG="$GALE_ROOT/benches/engine_control/prj-gale.conf" \
+              -DGALE_USE_SYNTH=ON \
+              -DENGINE_BENCH_SWEEP=long
+
+      - name: Run baseline in Renode
+        env:
+          ELF:           /tmp/engine-baseline-long/zephyr/zephyr.elf
+          BENCH_CSV_OUT: /tmp/engine-baseline-long/output.csv
+          GALE_ROOT:     ${{ github.workspace }}/gale
+        run: |
+          mkdir -p "$GITHUB_WORKSPACE/renode-baseline"
+          cd "$GITHUB_WORKSPACE/renode-baseline"
+          renode-test "$GALE_ROOT/benches/engine_control/renode/engine_stm32f4.robot"
+
+      - name: Run gale-via-synth in Renode
+        env:
+          ELF:           /tmp/engine-synth-long/zephyr/zephyr.elf
+          BENCH_CSV_OUT: /tmp/engine-synth-long/output.csv
+          GALE_ROOT:     ${{ github.workspace }}/gale
+        run: |
+          mkdir -p "$GITHUB_WORKSPACE/renode-gale-synth"
+          cd "$GITHUB_WORKSPACE/renode-gale-synth"
+          renode-test "$GALE_ROOT/benches/engine_control/renode/engine_stm32f4.robot"
+
+      - name: Tag events with run-id for analyzer
+        run: |
+          # Same shape as engine-bench-renode.yml.
+          python3 - <<'PY' \
+              /tmp/engine-baseline-long/output.csv baseline \
+              > /tmp/engine-baseline-long/events.csv
+          import sys
+          raw_path, variant = sys.argv[1], sys.argv[2]
+          with open(raw_path, 'rt', errors='replace') as f:
+              for line in f:
+                  line = line.rstrip('\r\n')
+                  if line.startswith('E,'):
+                      print(f"R1,{variant},{line}")
+                  elif line.startswith(('drops,', 'samples,', 'build,',
+                                        'cycles_per_sec,', 'target_samples,')):
+                      print(f"M,R1,{variant},{line}")
+                  elif line == '=== END ===':
+                      print(f"M,R1,{variant},END")
+          PY
+          python3 - <<'PY' \
+              /tmp/engine-synth-long/output.csv gale \
+              > /tmp/engine-synth-long/events.csv
+          import sys
+          raw_path, variant = sys.argv[1], sys.argv[2]
+          with open(raw_path, 'rt', errors='replace') as f:
+              for line in f:
+                  line = line.rstrip('\r\n')
+                  if line.startswith('E,'):
+                      print(f"R1,{variant},{line}")
+                  elif line.startswith(('drops,', 'samples,', 'build,',
+                                        'cycles_per_sec,', 'target_samples,')):
+                      print(f"M,R1,{variant},{line}")
+                  elif line == '=== END ===':
+                      print(f"M,R1,{variant},END")
+          PY
+
+      - name: Render comparison report (baseline vs gale-via-synth)
+        env:
+          GALE_ROOT: ${{ github.workspace }}/gale
+        run: |
+          python3 "$GALE_ROOT/benches/engine_control/analyze.py" \
+            --baseline /tmp/engine-baseline-long/events.csv \
+            --gale     /tmp/engine-synth-long/events.csv \
+            --runs 1 \
+            > /tmp/engine-comparison-synth.md || true
+          {
+            echo ''
+            echo '## Engine bench long under gale-via-synth — this run'
+            echo ''
+            echo 'Baseline = GCC -Os, no Gale.'
+            echo 'Compared variant = GCC + Gale via synth (wasm32 -> Cortex-M ET_REL -> libgale_ffi.a).'
+            echo 'The published numbers from the LTO blog post compare GCC baseline,'
+            echo 'GCC + Gale (rustc-direct), and LLVM + LTO + Gale. This workflow adds'
+            echo 'the 4th variant for a follow-up post.'
+            echo ''
+            cat /tmp/engine-comparison-synth.md
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload event streams + report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: engine-bench-renode-synth-long
+          path: |
+            /tmp/engine-baseline-long/output.csv
+            /tmp/engine-synth-long/output.csv
+            /tmp/engine-baseline-long/events.csv
+            /tmp/engine-synth-long/events.csv
+            renode-baseline/
+            renode-gale-synth/
+            /tmp/engine-comparison-synth.md
+          if-no-files-found: ignore

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -7,6 +7,27 @@
 #   3. Links both into the kernel
 
 # ==========================================================================
+# Experimental: wasm → synth (Cortex-M AOT) build mode
+#
+# When GALE_USE_SYNTH=ON, the gale-ffi crate is first compiled to wasm32
+# (cdylib), then run through the `synth` AOT compiler which emits a
+# Cortex-M ET_REL relocatable object. The object is wrapped into the
+# same `libgale_ffi.a` archive path the rest of the build expects, so no
+# downstream consumer changes are required — only the bytes inside
+# differ.
+#
+# Used for the 4th-variant cross-language LTO experiment. Off by default.
+# ==========================================================================
+option(GALE_USE_SYNTH
+  "Build gale-ffi via wasm→synth (Cortex-M AOT) instead of rustc-direct" OFF)
+
+if(GALE_USE_SYNTH)
+  find_program(SYNTH synth REQUIRED)
+  message(STATUS "Gale: GALE_USE_SYNTH=ON — using wasm→synth pipeline (Cortex-M AOT)")
+  message(STATUS "Gale: synth binary: ${SYNTH}")
+endif()
+
+# ==========================================================================
 # Cross-language LTO support (LLVM toolchain only)
 #
 # When building with ZEPHYR_TOOLCHAIN_VARIANT=llvm and CONFIG_LTO=y,
@@ -247,20 +268,71 @@ else()
   set(GALE_CARGO_FEATURE_ARGS --no-default-features)
 endif()
 
-add_custom_command(
-  OUTPUT ${GALE_FFI_LIB}
-  COMMAND ${CMAKE_COMMAND} -E env ${GALE_CARGO_ENV} ${GALE_CARGO_RUSTFLAGS_ENV}
-    cargo build ${GALE_CARGO_PROFILE_ARGS} ${CARGO_TARGET_ARGS}
-    ${GALE_CARGO_FEATURE_ARGS}
-    --manifest-path ${GALE_FFI_DIR}/Cargo.toml
-  DEPENDS
-    ${GALE_FFI_DIR}/Cargo.toml
-    ${GALE_FFI_DIR}/src/lib.rs
-    ${GALE_DIR}/plain/src/error.rs
-    ${GALE_DIR}/plain/src/lib.rs
-  COMMENT "Building Gale FFI static library for ${RUST_TARGET} [features: ${GALE_CARGO_FEATURES_STR}]"
-  VERBATIM
-)
+if(GALE_USE_SYNTH)
+  # wasm → synth → ar pipeline
+  # 1. cargo rustc -> gale_ffi.wasm (cdylib at wasm32-unknown-unknown)
+  # 2. synth compile -> gale_ffi_synth.o (ET_REL ARM EABI5 for Cortex-Mx)
+  # 3. ar rcs -> wraps the .o into libgale_ffi.a at the same path the
+  #    rustc-direct build would have produced; downstream consumers
+  #    (gale_sem.c link step, etc.) need no changes.
+  set(_GALE_WASM ${GALE_FFI_DIR}/target/wasm32-unknown-unknown/release/gale_ffi.wasm)
+  set(_GALE_SYNTH_OBJ ${CMAKE_CURRENT_BINARY_DIR}/gale_ffi_synth.o)
+
+  # Resolve synth --target from Kconfig CPU selection
+  if(CONFIG_CPU_CORTEX_M3)
+    set(_SYNTH_TARGET "cortex-m3")
+  elseif(CONFIG_CPU_CORTEX_M7)
+    set(_SYNTH_TARGET "cortex-m7")
+  else()
+    set(_SYNTH_TARGET "cortex-m4")
+  endif()
+  if(CONFIG_FPU)
+    set(_SYNTH_TARGET "${_SYNTH_TARGET}f")
+  endif()
+  message(STATUS "Gale: synth --target = ${_SYNTH_TARGET}")
+
+  # Ensure the libgale_ffi.a parent directory exists before ar runs
+  get_filename_component(_GALE_FFI_LIB_DIR ${GALE_FFI_LIB} DIRECTORY)
+
+  add_custom_command(
+    OUTPUT ${GALE_FFI_LIB}
+    # 1. gale-ffi -> wasm32 cdylib
+    COMMAND ${CMAKE_COMMAND} -E env ${GALE_CARGO_ENV}
+      cargo rustc --release --target wasm32-unknown-unknown
+      --manifest-path ${GALE_FFI_DIR}/Cargo.toml
+      ${GALE_CARGO_FEATURE_ARGS}
+      --crate-type=cdylib
+    # 2. wasm -> Cortex-M relocatable .o
+    COMMAND ${SYNTH} compile ${_GALE_WASM}
+      --target ${_SYNTH_TARGET} --all-exports --relocatable
+      -o ${_GALE_SYNTH_OBJ}
+    # 3. .o -> libgale_ffi.a at the path the rest of the build expects
+    COMMAND ${CMAKE_COMMAND} -E make_directory ${_GALE_FFI_LIB_DIR}
+    COMMAND ${CMAKE_AR} rcs ${GALE_FFI_LIB} ${_GALE_SYNTH_OBJ}
+    DEPENDS
+      ${GALE_FFI_DIR}/Cargo.toml
+      ${GALE_FFI_DIR}/src/lib.rs
+      ${GALE_DIR}/plain/src/error.rs
+      ${GALE_DIR}/plain/src/lib.rs
+    COMMENT "Gale: wasm -> synth (${_SYNTH_TARGET}) -> libgale_ffi.a [features: ${GALE_CARGO_FEATURES_STR}]"
+    VERBATIM
+  )
+else()
+  add_custom_command(
+    OUTPUT ${GALE_FFI_LIB}
+    COMMAND ${CMAKE_COMMAND} -E env ${GALE_CARGO_ENV} ${GALE_CARGO_RUSTFLAGS_ENV}
+      cargo build ${GALE_CARGO_PROFILE_ARGS} ${CARGO_TARGET_ARGS}
+      ${GALE_CARGO_FEATURE_ARGS}
+      --manifest-path ${GALE_FFI_DIR}/Cargo.toml
+    DEPENDS
+      ${GALE_FFI_DIR}/Cargo.toml
+      ${GALE_FFI_DIR}/src/lib.rs
+      ${GALE_DIR}/plain/src/error.rs
+      ${GALE_DIR}/plain/src/lib.rs
+    COMMENT "Building Gale FFI static library for ${RUST_TARGET} [features: ${GALE_CARGO_FEATURES_STR}]"
+    VERBATIM
+  )
+endif()
 
 add_custom_target(gale_ffi_build DEPENDS ${GALE_FFI_LIB})
 

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -354,7 +354,7 @@ if(GALE_USE_SYNTH)
   list(APPEND _GALE_PIPELINE_COMMANDS
     # 3. wasm -> Cortex-M relocatable .o
     COMMAND ${SYNTH} compile ${_GALE_WASM_FOR_SYNTH}
-      --target ${_SYNTH_TARGET} --all-exports --relocatable
+      --target ${_SYNTH_TARGET} --all-exports --relocatable --no-optimize
       -o ${_GALE_SYNTH_OBJ}
     # 4. .o -> libgale_ffi.a at the path the rest of the build expects
     COMMAND ${CMAKE_COMMAND} -E make_directory ${_GALE_FFI_LIB_DIR}

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -275,7 +275,9 @@ if(GALE_USE_SYNTH)
   # 3. ar rcs -> wraps the .o into libgale_ffi.a at the same path the
   #    rustc-direct build would have produced; downstream consumers
   #    (gale_sem.c link step, etc.) need no changes.
-  set(_GALE_WASM ${GALE_FFI_DIR}/target/wasm32-unknown-unknown/release/gale_ffi.wasm)
+  set(_GALE_WASM_RAW ${GALE_FFI_DIR}/target/wasm32-unknown-unknown/release/gale_ffi.wasm)
+  set(_GALE_WASM_OPT ${CMAKE_CURRENT_BINARY_DIR}/gale_ffi.opt.wasm)
+  set(_GALE_WASM_LOOM ${CMAKE_CURRENT_BINARY_DIR}/gale_ffi.loom.wasm)
   set(_GALE_SYNTH_OBJ ${CMAKE_CURRENT_BINARY_DIR}/gale_ffi_synth.o)
 
   # Resolve synth --target from Kconfig CPU selection
@@ -291,30 +293,83 @@ if(GALE_USE_SYNTH)
   endif()
   message(STATUS "Gale: synth --target = ${_SYNTH_TARGET}")
 
+  # Optional optimizers between rustc and synth. wasm-opt (Binaryen)
+  # gives aggressive size reduction; loom (pulseengine/loom) is the
+  # formally-verified Rust optimizer (each pass proved sound). Both
+  # are optional — if neither is on the path, the pipeline reduces to
+  # rustc -> synth as before.
+  find_program(WASM_OPT wasm-opt)
+  find_program(LOOM loom)
+  if(WASM_OPT)
+    message(STATUS "Gale: wasm-opt found at ${WASM_OPT} — will apply -Oz between rustc and synth")
+  endif()
+  if(LOOM)
+    message(STATUS "Gale: loom found at ${LOOM} — will apply formally-verified passes after wasm-opt")
+  endif()
+
+  # The "input to synth" is the result of whichever optimizer chain is
+  # available. Default: the raw rustc wasm. With wasm-opt: the -Oz wasm.
+  # With wasm-opt + loom: the loom-on-wasm-opt wasm.
+  if(WASM_OPT AND LOOM)
+    set(_GALE_WASM_FOR_SYNTH ${_GALE_WASM_LOOM})
+  elseif(WASM_OPT)
+    set(_GALE_WASM_FOR_SYNTH ${_GALE_WASM_OPT})
+  elseif(LOOM)
+    set(_GALE_WASM_FOR_SYNTH ${_GALE_WASM_LOOM})
+  else()
+    set(_GALE_WASM_FOR_SYNTH ${_GALE_WASM_RAW})
+  endif()
+
   # Ensure the libgale_ffi.a parent directory exists before ar runs
   get_filename_component(_GALE_FFI_LIB_DIR ${GALE_FFI_LIB} DIRECTORY)
 
-  add_custom_command(
-    OUTPUT ${GALE_FFI_LIB}
+  # Build the COMMAND list dynamically depending on which optimizers are
+  # present. We always run cargo and synth+ar; wasm-opt and loom slot in
+  # between if available.
+  set(_GALE_PIPELINE_COMMANDS
     # 1. gale-ffi -> wasm32 cdylib
     COMMAND ${CMAKE_COMMAND} -E env ${GALE_CARGO_ENV}
       cargo rustc --release --target wasm32-unknown-unknown
       --manifest-path ${GALE_FFI_DIR}/Cargo.toml
       ${GALE_CARGO_FEATURE_ARGS}
       --crate-type=cdylib
-    # 2. wasm -> Cortex-M relocatable .o
-    COMMAND ${SYNTH} compile ${_GALE_WASM}
+  )
+  if(WASM_OPT)
+    list(APPEND _GALE_PIPELINE_COMMANDS
+      # 2a. wasm-opt -Oz (Binaryen size optimizer)
+      COMMAND ${WASM_OPT} -Oz ${_GALE_WASM_RAW} -o ${_GALE_WASM_OPT}
+    )
+  endif()
+  if(LOOM)
+    if(WASM_OPT)
+      set(_LOOM_INPUT ${_GALE_WASM_OPT})
+    else()
+      set(_LOOM_INPUT ${_GALE_WASM_RAW})
+    endif()
+    list(APPEND _GALE_PIPELINE_COMMANDS
+      # 2b. loom optimize (formally-verified WASM optimizer)
+      COMMAND ${LOOM} optimize ${_LOOM_INPUT} --attestation false -o ${_GALE_WASM_LOOM}
+    )
+  endif()
+  list(APPEND _GALE_PIPELINE_COMMANDS
+    # 3. wasm -> Cortex-M relocatable .o
+    COMMAND ${SYNTH} compile ${_GALE_WASM_FOR_SYNTH}
       --target ${_SYNTH_TARGET} --all-exports --relocatable
       -o ${_GALE_SYNTH_OBJ}
-    # 3. .o -> libgale_ffi.a at the path the rest of the build expects
+    # 4. .o -> libgale_ffi.a at the path the rest of the build expects
     COMMAND ${CMAKE_COMMAND} -E make_directory ${_GALE_FFI_LIB_DIR}
     COMMAND ${CMAKE_AR} rcs ${GALE_FFI_LIB} ${_GALE_SYNTH_OBJ}
+  )
+
+  add_custom_command(
+    OUTPUT ${GALE_FFI_LIB}
+    ${_GALE_PIPELINE_COMMANDS}
     DEPENDS
       ${GALE_FFI_DIR}/Cargo.toml
       ${GALE_FFI_DIR}/src/lib.rs
       ${GALE_DIR}/plain/src/error.rs
       ${GALE_DIR}/plain/src/lib.rs
-    COMMENT "Gale: wasm -> synth (${_SYNTH_TARGET}) -> libgale_ffi.a [features: ${GALE_CARGO_FEATURES_STR}]"
+    COMMENT "Gale: wasm -> [wasm-opt] -> [loom] -> synth (${_SYNTH_TARGET}) -> libgale_ffi.a [features: ${GALE_CARGO_FEATURES_STR}]"
     VERBATIM
   )
 else()


### PR DESCRIPTION
## Summary

This PR adds a fourth gale build pipeline (rustc → wasm → **synth** → Cortex-M ELF, vs the published LTO post's three) and the cross-Renode A/B that proves the resulting **−34.5% handoff cycle delta** is in the actual instruction stream, not a simulator artifact.

**Headline result** (from CI run 25135305084, on branch HEAD before this PR's last two commits):

| Comparison | Baseline median | Gale median | Δ |
|---|---|---|---|
| (Headline) Renode 1.16.0: baseline vs gale | 354 cyc | 232 cyc | **−34.5%** |
| (a) Renode nightly: baseline vs gale | 354 cyc | 232 cyc | −34.5% (identical) |
| (b) Baseline ELF, 1.16.0 vs nightly | 354 cyc | 354 cyc | **0.0%** |
| (c) Gale ELF, 1.16.0 vs nightly | 232 cyc | 232 cyc | **0.0%** |

Same-ELF cross-version drift is exactly 0.0% on both paths. The −34.5% survives the model swap at the same magnitude. The delta is in the instruction stream, not in the simulator. Pooled gale max (236) < pooled baseline median (354).

## What's in this PR

- **New build mode**: `-DGALE_USE_SYNTH=ON` runs the gale-ffi crate through wasm-opt + synth (PulseEngine's Cortex-M AOT) to produce `libgale_ffi.a` at the same path the rustc-direct path produces it, no consumer changes.
- **Renode A/B** (commit \`ci(investigate): A/B same ELFs under Renode nightly\`): runs the same two ELFs under Renode 1.16.0 (container-pinned) and Renode nightly (downloaded fresh from \`builds.renode.io\`) so the cycle-model can be ruled in or out as the source of the delta. Includes three control comparisons (a/b/c above) rendered into the workflow's step summary.
- **Synth correctness control** (commit \`synth CI: B6 ...\`, audit P7 / DO-330 §6.1.4): a third gale build via rustc-direct (no synth in the chain) is run alongside under 1.16.0. If synth's handoff median agrees with rustc-direct's within ~3%, the synth-emitted ELF is a faithful Cortex-M codegen of the same Rust source. This is the cheapest tool-error-mitigation against synth being a research compiler.
- **Build manifest** (commit \`synth CI: ... D6\`, audit P9): every CI run now produces a \`manifest.txt\` capturing rustc / cargo / synth / wasm-opt / west / robotframework / SDK versions, Renode 1.16.0 + nightly versions, sha256 of the nightly tarball, sha256 of all built ELFs, sha256 + size of all CSV outputs, and \`west list\` for Zephyr fork + module shas. Bundled into the artifact alongside the three ELFs themselves.

Total Renode runs in this workflow: **5** (baseline 1.16.0, synth 1.16.0, rustc-direct 1.16.0, baseline nightly, synth nightly). \`timeout-minutes\` bumped 240 → 300.

## Audit pass

This PR was reviewed via the Mythos slop-hunt scaffold (10 personas + 1 fresh-session validator). Findings landed in this PR:

- **B6** (P7, tool qualification) — rustc-direct cross-check arm
- **D6** (P9, configuration management) — manifest.txt artifact
- **P10 validator refuted** P5's claim that PATH override was a no-op for renode-test (nightly tarball ships its own renode-test, sibling-resolution works)

Findings deferred to the flight-bench PR: B1-B5 (analyzer, bench-code).

## Test plan

- [ ] CI run on this branch lands green (run 25149225844 currently queued)
- [ ] `manifest.txt` appears in the artifact bundle and contains all expected fields
- [ ] Cross-Renode controls (b) and (c) report 0.0% drift on the same ELF — proves cycle model isn't the source
- [ ] Synth-vs-rustc-direct shows median agreement within 3% — proves synth's codegen is faithful
- [ ] Step summary renders 4 comparison sections cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)