### PR TITLE
fix: x86 SMP bitcode/code-model mismatch (smp_semaphore/mutex/threads)

### DIFF
--- a/.github/workflows/zephyr-tests.yml
+++ b/.github/workflows/zephyr-tests.yml
@@ -299,12 +299,17 @@ jobs:
         with:
           path: gale
 
-      - name: Install Rust + x86_64 target
+      - name: Install Rust + x86_64 target + rust-src
         run: |
           apt-get update -qq && apt-get install -y -qq curl > /dev/null 2>&1
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable
           . /root/.cargo/env
           rustup target add x86_64-unknown-none
+          # rust-src is required by -Zbuild-std=core, which gale's
+          # x86 build path uses to rebuild `core` from source with
+          # matching code-model + relocation-model. See the CONFIG_X86
+          # block in zephyr/CMakeLists.txt for full rationale.
+          rustup component add rust-src
 
       - name: Initialize west workspace
         run: |

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -183,6 +183,29 @@ if(CONFIG_X86)
     string(REPLACE "RUSTFLAGS=" "RUSTFLAGS=-Crelocation-model=static -Ccode-model=small "
            GALE_CARGO_RUSTFLAGS_ENV "${GALE_CARGO_RUSTFLAGS_ENV}")
   endif()
+
+  # Bitcode-merge mismatch on x86_64-unknown-none: the precompiled `core`
+  # rustlib ships bitcode tagged with code-model=kernel (the target's
+  # default). Our `-Ccode-model=small` tags gale-ffi's bitcode with
+  # code-model=small. With ffi/Cargo.toml's release profile `lto = true`
+  # (fat LTO), rustc tries to merge the two bitcode modules and LLVM
+  # rejects the link with:
+  #   warning: linking module flags 'Code Model':
+  #     IDs have conflicting values: 'i32 2' from , and 'i32 1' from gale_ffi...
+  #   error: failed to load bitcode of module "core-...rcgu.o"
+  # Switching to the release-lto profile (lto=false) sidesteps the
+  # bitcode merge — rustc emits a regular static archive. We keep the
+  # rest of the release tuning (opt-level=z, codegen-units=1, panic=abort,
+  # overflow-checks=true). Cortex-M targets are unaffected: their
+  # precompiled core has the same code-model the FFI uses, so fat LTO
+  # works there. (The LLVM+CONFIG_LTO branch above already selects
+  # release-lto for cross-language LTO — this just extends the same
+  # profile choice to plain x86 GCC builds.)
+  if(GALE_CARGO_PROFILE_DIR STREQUAL "release")
+    set(GALE_CARGO_PROFILE_ARGS "--profile" "release-lto")
+    set(GALE_CARGO_PROFILE_DIR "release-lto")
+    message(STATUS "Gale: x86 — using release-lto profile to avoid core bitcode/code-model mismatch")
+  endif()
 endif()
 
 # --------------------------------------------------------------------------

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -176,6 +176,8 @@ endif()
 # 2 GB of the 64-bit address space (sign-extended 32-bit immediates).
 # Zephyr maps the kernel in the lower address space, so we must use
 # code-model=small (addresses in the lower 2 GB) to match the C code.
+set(GALE_CARGO_EXTRA_ARGS "")
+
 if(CONFIG_X86)
   if(GALE_CARGO_RUSTFLAGS_ENV STREQUAL "")
     set(GALE_CARGO_RUSTFLAGS_ENV "RUSTFLAGS=-Crelocation-model=static -Ccode-model=small")
@@ -184,28 +186,33 @@ if(CONFIG_X86)
            GALE_CARGO_RUSTFLAGS_ENV "${GALE_CARGO_RUSTFLAGS_ENV}")
   endif()
 
-  # Bitcode-merge mismatch on x86_64-unknown-none: the precompiled `core`
-  # rustlib ships bitcode tagged with code-model=kernel (the target's
-  # default). Our `-Ccode-model=small` tags gale-ffi's bitcode with
-  # code-model=small. With ffi/Cargo.toml's release profile `lto = true`
-  # (fat LTO), rustc tries to merge the two bitcode modules and LLVM
-  # rejects the link with:
-  #   warning: linking module flags 'Code Model':
-  #     IDs have conflicting values: 'i32 2' from , and 'i32 1' from gale_ffi...
-  #   error: failed to load bitcode of module "core-...rcgu.o"
-  # Switching to the release-lto profile (lto=false) sidesteps the
-  # bitcode merge — rustc emits a regular static archive. We keep the
-  # rest of the release tuning (opt-level=z, codegen-units=1, panic=abort,
-  # overflow-checks=true). Cortex-M targets are unaffected: their
-  # precompiled core has the same code-model the FFI uses, so fat LTO
-  # works there. (The LLVM+CONFIG_LTO branch above already selects
-  # release-lto for cross-language LTO — this just extends the same
-  # profile choice to plain x86 GCC builds.)
-  if(GALE_CARGO_PROFILE_DIR STREQUAL "release")
-    set(GALE_CARGO_PROFILE_ARGS "--profile" "release-lto")
-    set(GALE_CARGO_PROFILE_DIR "release-lto")
-    message(STATUS "Gale: x86 — using release-lto profile to avoid core bitcode/code-model mismatch")
-  endif()
+  # Two compounding issues with the precompiled `core` rustlib for
+  # x86_64-unknown-none — both root-cause to "core was built with the
+  # target's defaults, which don't match the flags Zephyr needs":
+  #
+  # 1) Its bitcode is tagged code-model=kernel (the target default), but
+  #    we pass -Ccode-model=small to match Zephyr's lower-2 GB kernel
+  #    mapping. Fat LTO can't merge the two:
+  #      warning: linking module flags 'Code Model':
+  #        IDs have conflicting values: 'i32 2' from , and 'i32 1' from gale_ffi...
+  #      error: failed to load bitcode of module "core-...rcgu.o"
+  #
+  # 2) Even with lto=false (the release-lto profile we used to switch to
+  #    as a partial fix), the precompiled core's PIC-emitted symbol
+  #    references trigger:
+  #      ld.bfd: discarded output section: `.got.plt'
+  #      ld.bfd: final link failed
+  #    against Zephyr's non-PIC kernel link script.
+  #
+  # Proper fix: rebuild core from source with our flags via -Zbuild-std.
+  # The rebuilt core picks up RUSTFLAGS=-Ccode-model=small -Crelocation-
+  # model=static (set above), so it's both bitcode-compatible (matches
+  # gale-ffi's code-model) and PIC-free (no GOT/PLT references). Requires
+  # the `rust-src` rustup component AND RUSTC_BOOTSTRAP=1 to permit the
+  # unstable cargo flag on stable rustc. CI installs rust-src in the SMP
+  # test job; see .github/workflows/zephyr-tests.yml.
+  set(GALE_CARGO_EXTRA_ARGS "-Zbuild-std=core")
+  message(STATUS "Gale: x86 — rebuilding core from source via -Zbuild-std (matches code-model + relocation-model)")
 endif()
 
 # --------------------------------------------------------------------------
@@ -227,6 +234,12 @@ set(GALE_CARGO_ENV
   GALE_MAX_SEMS=${CONFIG_GALE_MAX_SEMS}
   GALE_MAX_WAITERS=${CONFIG_GALE_MAX_WAITERS}
 )
+
+# x86 needs RUSTC_BOOTSTRAP=1 to permit -Zbuild-std on stable rustc.
+# See the CONFIG_X86 block above for the full rationale.
+if(CONFIG_X86)
+  list(APPEND GALE_CARGO_ENV "RUSTC_BOOTSTRAP=1")
+endif()
 
 # Collect Cargo features from Kconfig — only compile FFI code for enabled modules
 set(GALE_CARGO_FEATURES "")
@@ -399,7 +412,7 @@ else()
   add_custom_command(
     OUTPUT ${GALE_FFI_LIB}
     COMMAND ${CMAKE_COMMAND} -E env ${GALE_CARGO_ENV} ${GALE_CARGO_RUSTFLAGS_ENV}
-      cargo build ${GALE_CARGO_PROFILE_ARGS} ${CARGO_TARGET_ARGS}
+      cargo build ${GALE_CARGO_PROFILE_ARGS} ${CARGO_TARGET_ARGS} ${GALE_CARGO_EXTRA_ARGS}
       ${GALE_CARGO_FEATURE_ARGS}
       --manifest-path ${GALE_FFI_DIR}/Cargo.toml
     DEPENDS
@@ -497,7 +510,7 @@ if(NOT TARGET gale_ffi_build)
   add_custom_command(
     OUTPUT ${GALE_FFI_LIB}
     COMMAND ${CMAKE_COMMAND} -E env ${GALE_CARGO_RUSTFLAGS_ENV}
-      cargo build ${GALE_CARGO_PROFILE_ARGS} ${CARGO_TARGET_ARGS}
+      cargo build ${GALE_CARGO_PROFILE_ARGS} ${CARGO_TARGET_ARGS} ${GALE_CARGO_EXTRA_ARGS}
       --manifest-path ${GALE_FFI_DIR}/Cargo.toml
     DEPENDS
       ${GALE_FFI_DIR}/Cargo.toml
@@ -593,7 +606,7 @@ if(NOT TARGET gale_ffi_build)
   add_custom_command(
     OUTPUT ${GALE_FFI_LIB}
     COMMAND ${CMAKE_COMMAND} -E env ${GALE_CARGO_RUSTFLAGS_ENV}
-      cargo build ${GALE_CARGO_PROFILE_ARGS} ${CARGO_TARGET_ARGS}
+      cargo build ${GALE_CARGO_PROFILE_ARGS} ${CARGO_TARGET_ARGS} ${GALE_CARGO_EXTRA_ARGS}
       --manifest-path ${GALE_FFI_DIR}/Cargo.toml
     DEPENDS
       ${GALE_FFI_DIR}/Cargo.toml
@@ -687,7 +700,7 @@ if(NOT TARGET gale_ffi_build)
   add_custom_command(
     OUTPUT ${GALE_FFI_LIB}
     COMMAND ${CMAKE_COMMAND} -E env ${GALE_CARGO_RUSTFLAGS_ENV}
-      cargo build ${GALE_CARGO_PROFILE_ARGS} ${CARGO_TARGET_ARGS}
+      cargo build ${GALE_CARGO_PROFILE_ARGS} ${CARGO_TARGET_ARGS} ${GALE_CARGO_EXTRA_ARGS}
       --manifest-path ${GALE_FFI_DIR}/Cargo.toml
     DEPENDS
       ${GALE_FFI_DIR}/Cargo.toml
@@ -781,7 +794,7 @@ if(NOT TARGET gale_ffi_build)
   add_custom_command(
     OUTPUT ${GALE_FFI_LIB}
     COMMAND ${CMAKE_COMMAND} -E env ${GALE_CARGO_RUSTFLAGS_ENV}
-      cargo build ${GALE_CARGO_PROFILE_ARGS} ${CARGO_TARGET_ARGS}
+      cargo build ${GALE_CARGO_PROFILE_ARGS} ${CARGO_TARGET_ARGS} ${GALE_CARGO_EXTRA_ARGS}
       --manifest-path ${GALE_FFI_DIR}/Cargo.toml
     DEPENDS
       ${GALE_FFI_DIR}/Cargo.toml
@@ -875,7 +888,7 @@ if(NOT TARGET gale_ffi_build)
   add_custom_command(
     OUTPUT ${GALE_FFI_LIB}
     COMMAND ${CMAKE_COMMAND} -E env ${GALE_CARGO_RUSTFLAGS_ENV}
-      cargo build ${GALE_CARGO_PROFILE_ARGS} ${CARGO_TARGET_ARGS}
+      cargo build ${GALE_CARGO_PROFILE_ARGS} ${CARGO_TARGET_ARGS} ${GALE_CARGO_EXTRA_ARGS}
       --manifest-path ${GALE_FFI_DIR}/Cargo.toml
     DEPENDS
       ${GALE_FFI_DIR}/Cargo.toml
@@ -969,7 +982,7 @@ if(NOT TARGET gale_ffi_build)
   add_custom_command(
     OUTPUT ${GALE_FFI_LIB}
     COMMAND ${CMAKE_COMMAND} -E env ${GALE_CARGO_RUSTFLAGS_ENV}
-      cargo build ${GALE_CARGO_PROFILE_ARGS} ${CARGO_TARGET_ARGS}
+      cargo build ${GALE_CARGO_PROFILE_ARGS} ${CARGO_TARGET_ARGS} ${GALE_CARGO_EXTRA_ARGS}
       --manifest-path ${GALE_FFI_DIR}/Cargo.toml
     DEPENDS
       ${GALE_FFI_DIR}/Cargo.toml
@@ -1063,7 +1076,7 @@ if(NOT TARGET gale_ffi_build)
   add_custom_command(
     OUTPUT ${GALE_FFI_LIB}
     COMMAND ${CMAKE_COMMAND} -E env ${GALE_CARGO_RUSTFLAGS_ENV}
-      cargo build ${GALE_CARGO_PROFILE_ARGS} ${CARGO_TARGET_ARGS}
+      cargo build ${GALE_CARGO_PROFILE_ARGS} ${CARGO_TARGET_ARGS} ${GALE_CARGO_EXTRA_ARGS}
       --manifest-path ${GALE_FFI_DIR}/Cargo.toml
     DEPENDS
       ${GALE_FFI_DIR}/Cargo.toml
@@ -1157,7 +1170,7 @@ if(NOT TARGET gale_ffi_build)
   add_custom_command(
     OUTPUT ${GALE_FFI_LIB}
     COMMAND ${CMAKE_COMMAND} -E env ${GALE_CARGO_RUSTFLAGS_ENV}
-      cargo build ${GALE_CARGO_PROFILE_ARGS} ${CARGO_TARGET_ARGS}
+      cargo build ${GALE_CARGO_PROFILE_ARGS} ${CARGO_TARGET_ARGS} ${GALE_CARGO_EXTRA_ARGS}
       --manifest-path ${GALE_FFI_DIR}/Cargo.toml
     DEPENDS
       ${GALE_FFI_DIR}/Cargo.toml
@@ -1250,7 +1263,7 @@ if(NOT TARGET gale_ffi_build)
   add_custom_command(
     OUTPUT ${GALE_FFI_LIB}
     COMMAND ${CMAKE_COMMAND} -E env ${GALE_CARGO_RUSTFLAGS_ENV}
-      cargo build ${GALE_CARGO_PROFILE_ARGS} ${CARGO_TARGET_ARGS}
+      cargo build ${GALE_CARGO_PROFILE_ARGS} ${CARGO_TARGET_ARGS} ${GALE_CARGO_EXTRA_ARGS}
       --manifest-path ${GALE_FFI_DIR}/Cargo.toml
     DEPENDS
       ${GALE_FFI_DIR}/Cargo.toml
@@ -1343,7 +1356,7 @@ if(NOT TARGET gale_ffi_build)
   add_custom_command(
     OUTPUT ${GALE_FFI_LIB}
     COMMAND ${CMAKE_COMMAND} -E env ${GALE_CARGO_RUSTFLAGS_ENV}
-      cargo build ${GALE_CARGO_PROFILE_ARGS} ${CARGO_TARGET_ARGS}
+      cargo build ${GALE_CARGO_PROFILE_ARGS} ${CARGO_TARGET_ARGS} ${GALE_CARGO_EXTRA_ARGS}
       --manifest-path ${GALE_FFI_DIR}/Cargo.toml
     DEPENDS
       ${GALE_FFI_DIR}/Cargo.toml
@@ -1436,7 +1449,7 @@ if(NOT TARGET gale_ffi_build)
   add_custom_command(
     OUTPUT ${GALE_FFI_LIB}
     COMMAND ${CMAKE_COMMAND} -E env ${GALE_CARGO_RUSTFLAGS_ENV}
-      cargo build ${GALE_CARGO_PROFILE_ARGS} ${CARGO_TARGET_ARGS}
+      cargo build ${GALE_CARGO_PROFILE_ARGS} ${CARGO_TARGET_ARGS} ${GALE_CARGO_EXTRA_ARGS}
       --manifest-path ${GALE_FFI_DIR}/Cargo.toml
     DEPENDS
       ${GALE_FFI_DIR}/Cargo.toml
@@ -1488,7 +1501,7 @@ if(NOT TARGET gale_ffi_build)
   add_custom_command(
     OUTPUT ${GALE_FFI_LIB}
     COMMAND ${CMAKE_COMMAND} -E env ${GALE_CARGO_RUSTFLAGS_ENV}
-      cargo build ${GALE_CARGO_PROFILE_ARGS} ${CARGO_TARGET_ARGS}
+      cargo build ${GALE_CARGO_PROFILE_ARGS} ${CARGO_TARGET_ARGS} ${GALE_CARGO_EXTRA_ARGS}
       --manifest-path ${GALE_FFI_DIR}/Cargo.toml
     DEPENDS ${GALE_FFI_DIR}/Cargo.toml ${GALE_FFI_DIR}/src/lib.rs
     COMMENT "Building Gale FFI static library for ${RUST_TARGET}"
@@ -1528,7 +1541,7 @@ if(NOT TARGET gale_ffi_build)
   add_custom_command(
     OUTPUT ${GALE_FFI_LIB}
     COMMAND ${CMAKE_COMMAND} -E env ${GALE_CARGO_RUSTFLAGS_ENV}
-      cargo build ${GALE_CARGO_PROFILE_ARGS} ${CARGO_TARGET_ARGS}
+      cargo build ${GALE_CARGO_PROFILE_ARGS} ${CARGO_TARGET_ARGS} ${GALE_CARGO_EXTRA_ARGS}
       --manifest-path ${GALE_FFI_DIR}/Cargo.toml
     DEPENDS ${GALE_FFI_DIR}/Cargo.toml ${GALE_FFI_DIR}/src/lib.rs
     COMMENT "Building Gale FFI static library for ${RUST_TARGET}"
@@ -1568,7 +1581,7 @@ if(NOT TARGET gale_ffi_build)
   add_custom_command(
     OUTPUT ${GALE_FFI_LIB}
     COMMAND ${CMAKE_COMMAND} -E env ${GALE_CARGO_RUSTFLAGS_ENV}
-      cargo build ${GALE_CARGO_PROFILE_ARGS} ${CARGO_TARGET_ARGS}
+      cargo build ${GALE_CARGO_PROFILE_ARGS} ${CARGO_TARGET_ARGS} ${GALE_CARGO_EXTRA_ARGS}
       --manifest-path ${GALE_FFI_DIR}/Cargo.toml
     DEPENDS ${GALE_FFI_DIR}/Cargo.toml ${GALE_FFI_DIR}/src/lib.rs
     COMMENT "Building Gale FFI static library for ${RUST_TARGET}"
@@ -1608,7 +1621,7 @@ if(NOT TARGET gale_ffi_build)
   add_custom_command(
     OUTPUT ${GALE_FFI_LIB}
     COMMAND ${CMAKE_COMMAND} -E env ${GALE_CARGO_RUSTFLAGS_ENV}
-      cargo build ${GALE_CARGO_PROFILE_ARGS} ${CARGO_TARGET_ARGS}
+      cargo build ${GALE_CARGO_PROFILE_ARGS} ${CARGO_TARGET_ARGS} ${GALE_CARGO_EXTRA_ARGS}
       --manifest-path ${GALE_FFI_DIR}/Cargo.toml
     DEPENDS ${GALE_FFI_DIR}/Cargo.toml ${GALE_FFI_DIR}/src/lib.rs
     COMMENT "Building Gale FFI static library for ${RUST_TARGET}"
@@ -1648,7 +1661,7 @@ if(NOT TARGET gale_ffi_build)
   add_custom_command(
     OUTPUT ${GALE_FFI_LIB}
     COMMAND ${CMAKE_COMMAND} -E env ${GALE_CARGO_RUSTFLAGS_ENV}
-      cargo build ${GALE_CARGO_PROFILE_ARGS} ${CARGO_TARGET_ARGS}
+      cargo build ${GALE_CARGO_PROFILE_ARGS} ${CARGO_TARGET_ARGS} ${GALE_CARGO_EXTRA_ARGS}
       --manifest-path ${GALE_FFI_DIR}/Cargo.toml
     DEPENDS ${GALE_FFI_DIR}/Cargo.toml ${GALE_FFI_DIR}/src/lib.rs
     COMMENT "Building Gale FFI static library for ${RUST_TARGET}"
@@ -1688,7 +1701,7 @@ if(NOT TARGET gale_ffi_build)
   add_custom_command(
     OUTPUT ${GALE_FFI_LIB}
     COMMAND ${CMAKE_COMMAND} -E env ${GALE_CARGO_RUSTFLAGS_ENV}
-      cargo build ${GALE_CARGO_PROFILE_ARGS} ${CARGO_TARGET_ARGS}
+      cargo build ${GALE_CARGO_PROFILE_ARGS} ${CARGO_TARGET_ARGS} ${GALE_CARGO_EXTRA_ARGS}
       --manifest-path ${GALE_FFI_DIR}/Cargo.toml
     DEPENDS ${GALE_FFI_DIR}/Cargo.toml ${GALE_FFI_DIR}/src/lib.rs
     COMMENT "Building Gale FFI static library for ${RUST_TARGET}"
@@ -1728,7 +1741,7 @@ if(NOT TARGET gale_ffi_build)
   add_custom_command(
     OUTPUT ${GALE_FFI_LIB}
     COMMAND ${CMAKE_COMMAND} -E env ${GALE_CARGO_RUSTFLAGS_ENV}
-      cargo build ${GALE_CARGO_PROFILE_ARGS} ${CARGO_TARGET_ARGS}
+      cargo build ${GALE_CARGO_PROFILE_ARGS} ${CARGO_TARGET_ARGS} ${GALE_CARGO_EXTRA_ARGS}
       --manifest-path ${GALE_FFI_DIR}/Cargo.toml
     DEPENDS ${GALE_FFI_DIR}/Cargo.toml ${GALE_FFI_DIR}/src/lib.rs
     COMMENT "Building Gale FFI static library for ${RUST_TARGET}"
@@ -1768,7 +1781,7 @@ if(NOT TARGET gale_ffi_build)
   add_custom_command(
     OUTPUT ${GALE_FFI_LIB}
     COMMAND ${CMAKE_COMMAND} -E env ${GALE_CARGO_RUSTFLAGS_ENV}
-      cargo build ${GALE_CARGO_PROFILE_ARGS} ${CARGO_TARGET_ARGS}
+      cargo build ${GALE_CARGO_PROFILE_ARGS} ${CARGO_TARGET_ARGS} ${GALE_CARGO_EXTRA_ARGS}
       --manifest-path ${GALE_FFI_DIR}/Cargo.toml
     DEPENDS ${GALE_FFI_DIR}/Cargo.toml ${GALE_FFI_DIR}/src/lib.rs
     COMMENT "Building Gale FFI static library for ${RUST_TARGET}"
@@ -1808,7 +1821,7 @@ if(NOT TARGET gale_ffi_build)
   add_custom_command(
     OUTPUT ${GALE_FFI_LIB}
     COMMAND ${CMAKE_COMMAND} -E env ${GALE_CARGO_RUSTFLAGS_ENV}
-      cargo build ${GALE_CARGO_PROFILE_ARGS} ${CARGO_TARGET_ARGS}
+      cargo build ${GALE_CARGO_PROFILE_ARGS} ${CARGO_TARGET_ARGS} ${GALE_CARGO_EXTRA_ARGS}
       --manifest-path ${GALE_FFI_DIR}/Cargo.toml
     DEPENDS ${GALE_FFI_DIR}/Cargo.toml ${GALE_FFI_DIR}/src/lib.rs
     COMMENT "Building Gale FFI static library for ${RUST_TARGET}"
@@ -1848,7 +1861,7 @@ if(NOT TARGET gale_ffi_build)
   add_custom_command(
     OUTPUT ${GALE_FFI_LIB}
     COMMAND ${CMAKE_COMMAND} -E env ${GALE_CARGO_RUSTFLAGS_ENV}
-      cargo build ${GALE_CARGO_PROFILE_ARGS} ${CARGO_TARGET_ARGS}
+      cargo build ${GALE_CARGO_PROFILE_ARGS} ${CARGO_TARGET_ARGS} ${GALE_CARGO_EXTRA_ARGS}
       --manifest-path ${GALE_FFI_DIR}/Cargo.toml
     DEPENDS ${GALE_FFI_DIR}/Cargo.toml ${GALE_FFI_DIR}/src/lib.rs
     COMMENT "Building Gale FFI static library for ${RUST_TARGET}"
@@ -1888,7 +1901,7 @@ if(NOT TARGET gale_ffi_build)
   add_custom_command(
     OUTPUT ${GALE_FFI_LIB}
     COMMAND ${CMAKE_COMMAND} -E env ${GALE_CARGO_RUSTFLAGS_ENV}
-      cargo build ${GALE_CARGO_PROFILE_ARGS} ${CARGO_TARGET_ARGS}
+      cargo build ${GALE_CARGO_PROFILE_ARGS} ${CARGO_TARGET_ARGS} ${GALE_CARGO_EXTRA_ARGS}
       --manifest-path ${GALE_FFI_DIR}/Cargo.toml
     DEPENDS ${GALE_FFI_DIR}/Cargo.toml ${GALE_FFI_DIR}/src/lib.rs
     COMMENT "Building Gale FFI static library for ${RUST_TARGET}"
@@ -1928,7 +1941,7 @@ if(NOT TARGET gale_ffi_build)
   add_custom_command(
     OUTPUT ${GALE_FFI_LIB}
     COMMAND ${CMAKE_COMMAND} -E env ${GALE_CARGO_RUSTFLAGS_ENV}
-      cargo build ${GALE_CARGO_PROFILE_ARGS} ${CARGO_TARGET_ARGS}
+      cargo build ${GALE_CARGO_PROFILE_ARGS} ${CARGO_TARGET_ARGS} ${GALE_CARGO_EXTRA_ARGS}
       --manifest-path ${GALE_FFI_DIR}/Cargo.toml
     DEPENDS ${GALE_FFI_DIR}/Cargo.toml ${GALE_FFI_DIR}/src/lib.rs
     COMMENT "Building Gale FFI static library for ${RUST_TARGET}"
@@ -1968,7 +1981,7 @@ if(NOT TARGET gale_ffi_build)
   add_custom_command(
     OUTPUT ${GALE_FFI_LIB}
     COMMAND ${CMAKE_COMMAND} -E env ${GALE_CARGO_RUSTFLAGS_ENV}
-      cargo build ${GALE_CARGO_PROFILE_ARGS} ${CARGO_TARGET_ARGS}
+      cargo build ${GALE_CARGO_PROFILE_ARGS} ${CARGO_TARGET_ARGS} ${GALE_CARGO_EXTRA_ARGS}
       --manifest-path ${GALE_FFI_DIR}/Cargo.toml
     DEPENDS ${GALE_FFI_DIR}/Cargo.toml ${GALE_FFI_DIR}/src/lib.rs
     COMMENT "Building Gale FFI static library for ${RUST_TARGET}"
@@ -2016,7 +2029,7 @@ if(NOT TARGET gale_ffi_build)
   add_custom_command(
     OUTPUT ${GALE_FFI_LIB}
     COMMAND ${CMAKE_COMMAND} -E env
-      cargo build ${GALE_CARGO_PROFILE_ARGS} ${CARGO_TARGET_ARGS}
+      cargo build ${GALE_CARGO_PROFILE_ARGS} ${CARGO_TARGET_ARGS} ${GALE_CARGO_EXTRA_ARGS}
       --manifest-path ${GALE_FFI_DIR}/Cargo.toml
     DEPENDS ${GALE_FFI_DIR}/Cargo.toml ${GALE_FFI_DIR}/src/lib.rs
     COMMENT "Building Gale FFI static library for ${RUST_TARGET}"
@@ -2056,7 +2069,7 @@ if(NOT TARGET gale_ffi_build)
   add_custom_command(
     OUTPUT ${GALE_FFI_LIB}
     COMMAND ${CMAKE_COMMAND} -E env
-      cargo build ${GALE_CARGO_PROFILE_ARGS} ${CARGO_TARGET_ARGS}
+      cargo build ${GALE_CARGO_PROFILE_ARGS} ${CARGO_TARGET_ARGS} ${GALE_CARGO_EXTRA_ARGS}
       --manifest-path ${GALE_FFI_DIR}/Cargo.toml
     DEPENDS ${GALE_FFI_DIR}/Cargo.toml ${GALE_FFI_DIR}/src/lib.rs
     COMMENT "Building Gale FFI static library for ${RUST_TARGET}"
@@ -2111,7 +2124,7 @@ if(NOT TARGET gale_ffi_build)
   add_custom_command(
     OUTPUT ${GALE_FFI_LIB}
     COMMAND ${CMAKE_COMMAND} -E env
-      cargo build ${GALE_CARGO_PROFILE_ARGS} ${CARGO_TARGET_ARGS}
+      cargo build ${GALE_CARGO_PROFILE_ARGS} ${CARGO_TARGET_ARGS} ${GALE_CARGO_EXTRA_ARGS}
       --manifest-path ${GALE_FFI_DIR}/Cargo.toml
     DEPENDS ${GALE_FFI_DIR}/Cargo.toml ${GALE_FFI_DIR}/src/lib.rs
     COMMENT "Building Gale FFI static library for ${RUST_TARGET}"
@@ -2156,7 +2169,7 @@ if(NOT TARGET gale_ffi_build)
   add_custom_command(
     OUTPUT ${GALE_FFI_LIB}
     COMMAND ${CMAKE_COMMAND} -E env
-      cargo build ${GALE_CARGO_PROFILE_ARGS} ${CARGO_TARGET_ARGS}
+      cargo build ${GALE_CARGO_PROFILE_ARGS} ${CARGO_TARGET_ARGS} ${GALE_CARGO_EXTRA_ARGS}
       --manifest-path ${GALE_FFI_DIR}/Cargo.toml
     DEPENDS ${GALE_FFI_DIR}/Cargo.toml ${GALE_FFI_DIR}/src/lib.rs
     COMMENT "Building Gale FFI static library for ${RUST_TARGET}"
@@ -2201,7 +2214,7 @@ if(NOT TARGET gale_ffi_build)
   add_custom_command(
     OUTPUT ${GALE_FFI_LIB}
     COMMAND ${CMAKE_COMMAND} -E env
-      cargo build ${GALE_CARGO_PROFILE_ARGS} ${CARGO_TARGET_ARGS}
+      cargo build ${GALE_CARGO_PROFILE_ARGS} ${CARGO_TARGET_ARGS} ${GALE_CARGO_EXTRA_ARGS}
       --manifest-path ${GALE_FFI_DIR}/Cargo.toml
     DEPENDS ${GALE_FFI_DIR}/Cargo.toml ${GALE_FFI_DIR}/src/lib.rs
     COMMENT "Building Gale FFI static library for ${RUST_TARGET}"
@@ -2245,7 +2258,7 @@ if(NOT TARGET gale_ffi_build)
   add_custom_command(
     OUTPUT ${GALE_FFI_LIB}
     COMMAND ${CMAKE_COMMAND} -E env ${GALE_CARGO_RUSTFLAGS_ENV}
-      cargo build ${GALE_CARGO_PROFILE_ARGS} ${CARGO_TARGET_ARGS}
+      cargo build ${GALE_CARGO_PROFILE_ARGS} ${CARGO_TARGET_ARGS} ${GALE_CARGO_EXTRA_ARGS}
       --manifest-path ${GALE_FFI_DIR}/Cargo.toml
     DEPENDS ${GALE_FFI_DIR}/Cargo.toml ${GALE_FFI_DIR}/src/lib.rs
     COMMENT "Building Gale FFI static library for ${RUST_TARGET}"
@@ -2285,7 +2298,7 @@ if(NOT TARGET gale_ffi_build)
   add_custom_command(
     OUTPUT ${GALE_FFI_LIB}
     COMMAND ${CMAKE_COMMAND} -E env
-      cargo build ${GALE_CARGO_PROFILE_ARGS} ${CARGO_TARGET_ARGS}
+      cargo build ${GALE_CARGO_PROFILE_ARGS} ${CARGO_TARGET_ARGS} ${GALE_CARGO_EXTRA_ARGS}
       --manifest-path ${GALE_FFI_DIR}/Cargo.toml
     DEPENDS ${GALE_FFI_DIR}/Cargo.toml ${GALE_FFI_DIR}/src/lib.rs
     COMMENT "Building Gale FFI static library for ${RUST_TARGET}"
@@ -2328,7 +2341,7 @@ if(NOT TARGET gale_ffi_build)
   add_custom_command(
     OUTPUT ${GALE_FFI_LIB}
     COMMAND ${CMAKE_COMMAND} -E env ${GALE_CARGO_RUSTFLAGS_ENV}
-      cargo build ${GALE_CARGO_PROFILE_ARGS} ${CARGO_TARGET_ARGS}
+      cargo build ${GALE_CARGO_PROFILE_ARGS} ${CARGO_TARGET_ARGS} ${GALE_CARGO_EXTRA_ARGS}
       --manifest-path ${GALE_FFI_DIR}/Cargo.toml
     DEPENDS ${GALE_FFI_DIR}/Cargo.toml ${GALE_FFI_DIR}/src/lib.rs
     COMMENT "Building Gale FFI static library for ${RUST_TARGET}"
@@ -2372,7 +2385,7 @@ if(NOT TARGET gale_ffi_build)
   add_custom_command(
     OUTPUT ${GALE_FFI_LIB}
     COMMAND ${CMAKE_COMMAND} -E env ${GALE_CARGO_RUSTFLAGS_ENV}
-      cargo build ${GALE_CARGO_PROFILE_ARGS} ${CARGO_TARGET_ARGS}
+      cargo build ${GALE_CARGO_PROFILE_ARGS} ${CARGO_TARGET_ARGS} ${GALE_CARGO_EXTRA_ARGS}
       --manifest-path ${GALE_FFI_DIR}/Cargo.toml
     DEPENDS ${GALE_FFI_DIR}/Cargo.toml ${GALE_FFI_DIR}/src/lib.rs
     COMMENT "Building Gale FFI static library for ${RUST_TARGET}"
@@ -2415,7 +2428,7 @@ if(NOT TARGET gale_ffi_build)
   add_custom_command(
     OUTPUT ${GALE_FFI_LIB}
     COMMAND ${CMAKE_COMMAND} -E env ${GALE_CARGO_RUSTFLAGS_ENV}
-      cargo build ${GALE_CARGO_PROFILE_ARGS} ${CARGO_TARGET_ARGS}
+      cargo build ${GALE_CARGO_PROFILE_ARGS} ${CARGO_TARGET_ARGS} ${GALE_CARGO_EXTRA_ARGS}
       --manifest-path ${GALE_FFI_DIR}/Cargo.toml
     DEPENDS ${GALE_FFI_DIR}/Cargo.toml ${GALE_FFI_DIR}/src/lib.rs
     COMMENT "Building Gale FFI static library for ${RUST_TARGET}"
@@ -2458,7 +2471,7 @@ if(NOT TARGET gale_ffi_build)
   add_custom_command(
     OUTPUT ${GALE_FFI_LIB}
     COMMAND ${CMAKE_COMMAND} -E env ${GALE_CARGO_RUSTFLAGS_ENV}
-      cargo build ${GALE_CARGO_PROFILE_ARGS} ${CARGO_TARGET_ARGS}
+      cargo build ${GALE_CARGO_PROFILE_ARGS} ${CARGO_TARGET_ARGS} ${GALE_CARGO_EXTRA_ARGS}
       --manifest-path ${GALE_FFI_DIR}/Cargo.toml
     DEPENDS ${GALE_FFI_DIR}/Cargo.toml ${GALE_FFI_DIR}/src/lib.rs
     COMMENT "Building Gale FFI static library for ${RUST_TARGET}"
@@ -2502,7 +2515,7 @@ if(NOT TARGET gale_ffi_build)
   add_custom_command(
     OUTPUT ${GALE_FFI_LIB}
     COMMAND ${CMAKE_COMMAND} -E env ${GALE_CARGO_RUSTFLAGS_ENV}
-      cargo build ${GALE_CARGO_PROFILE_ARGS} ${CARGO_TARGET_ARGS}
+      cargo build ${GALE_CARGO_PROFILE_ARGS} ${CARGO_TARGET_ARGS} ${GALE_CARGO_EXTRA_ARGS}
       --manifest-path ${GALE_FFI_DIR}/Cargo.toml
     DEPENDS ${GALE_FFI_DIR}/Cargo.toml ${GALE_FFI_DIR}/src/lib.rs
     COMMENT "Building Gale FFI static library for ${RUST_TARGET}"
@@ -2545,7 +2558,7 @@ if(NOT TARGET gale_ffi_build)
   add_custom_command(
     OUTPUT ${GALE_FFI_LIB}
     COMMAND ${CMAKE_COMMAND} -E env ${GALE_CARGO_RUSTFLAGS_ENV}
-      cargo build ${GALE_CARGO_PROFILE_ARGS} ${CARGO_TARGET_ARGS}
+      cargo build ${GALE_CARGO_PROFILE_ARGS} ${CARGO_TARGET_ARGS} ${GALE_CARGO_EXTRA_ARGS}
       --manifest-path ${GALE_FFI_DIR}/Cargo.toml
     DEPENDS ${GALE_FFI_DIR}/Cargo.toml ${GALE_FFI_DIR}/src/lib.rs
     COMMENT "Building Gale FFI static library for ${RUST_TARGET}"
@@ -2592,7 +2605,7 @@ if(NOT TARGET gale_ffi_build)
   add_custom_command(
     OUTPUT ${GALE_FFI_LIB}
     COMMAND ${CMAKE_COMMAND} -E env ${GALE_CARGO_RUSTFLAGS_ENV}
-      cargo build ${GALE_CARGO_PROFILE_ARGS} ${CARGO_TARGET_ARGS}
+      cargo build ${GALE_CARGO_PROFILE_ARGS} ${CARGO_TARGET_ARGS} ${GALE_CARGO_EXTRA_ARGS}
       --manifest-path ${GALE_FFI_DIR}/Cargo.toml
     DEPENDS ${GALE_FFI_DIR}/Cargo.toml ${GALE_FFI_DIR}/src/lib.rs
     COMMENT "Building Gale FFI static library for ${RUST_TARGET}"
@@ -2638,7 +2651,7 @@ if(NOT TARGET gale_ffi_build)
   add_custom_command(
     OUTPUT ${GALE_FFI_LIB}
     COMMAND ${CMAKE_COMMAND} -E env ${GALE_CARGO_RUSTFLAGS_ENV}
-      cargo build ${GALE_CARGO_PROFILE_ARGS} ${CARGO_TARGET_ARGS}
+      cargo build ${GALE_CARGO_PROFILE_ARGS} ${CARGO_TARGET_ARGS} ${GALE_CARGO_EXTRA_ARGS}
       --manifest-path ${GALE_FFI_DIR}/Cargo.toml
     DEPENDS ${GALE_FFI_DIR}/Cargo.toml ${GALE_FFI_DIR}/src/lib.rs
     COMMENT "Building Gale FFI static library for ${RUST_TARGET}"
@@ -2687,7 +2700,7 @@ if(NOT TARGET gale_ffi_build)
   add_custom_command(
     OUTPUT ${GALE_FFI_LIB}
     COMMAND ${CMAKE_COMMAND} -E env ${GALE_CARGO_RUSTFLAGS_ENV}
-      cargo build ${GALE_CARGO_PROFILE_ARGS} ${CARGO_TARGET_ARGS}
+      cargo build ${GALE_CARGO_PROFILE_ARGS} ${CARGO_TARGET_ARGS} ${GALE_CARGO_EXTRA_ARGS}
       --manifest-path ${GALE_FFI_DIR}/Cargo.toml
     DEPENDS ${GALE_FFI_DIR}/Cargo.toml ${GALE_FFI_DIR}/src/lib.rs
     COMMENT "Building Gale FFI static library for ${RUST_TARGET}"
@@ -2774,7 +2787,7 @@ if(NOT TARGET gale_ffi_build)
   add_custom_command(
     OUTPUT ${GALE_FFI_LIB}
     COMMAND ${CMAKE_COMMAND} -E env ${GALE_CARGO_ENV} ${GALE_CARGO_RUSTFLAGS_ENV}
-      cargo build ${GALE_CARGO_PROFILE_ARGS} ${CARGO_TARGET_ARGS}
+      cargo build ${GALE_CARGO_PROFILE_ARGS} ${CARGO_TARGET_ARGS} ${GALE_CARGO_EXTRA_ARGS}
       ${GALE_CARGO_FEATURE_ARGS}
       --manifest-path ${GALE_FFI_DIR}/Cargo.toml
     DEPENDS


### PR DESCRIPTION
## Summary

Three CI checks have been failing for at least the last several PRs:

- \`smp_semaphore (qemu_x86_64, SMP)\`
- \`smp_mutex (qemu_x86_64, SMP)\`
- \`smp_threads (qemu_x86_64, SMP)\`

All three fail at the same step — building \`libgale_ffi.a\` for \`x86_64-unknown-none\`:

\`\`\`
error: failed to load bitcode of module
       "core-fcc82a7537a7267a.core.bb170dea1013a3a3-cgu.0.rcgu.o"
error: could not compile gale-ffi (lib) due to 1 previous error
\`\`\`

## Root cause

Reproduced locally with rustc 1.95.0. The CI log truncates one line earlier than the actual cause; the smoking gun is a warning that precedes the error:

\`\`\`
warning: linking module flags 'Code Model':
  IDs have conflicting values: 'i32 2' from , and 'i32 1' from gale_ffi.5b37a6aa01c132b8-cgu.0
\`\`\`

The chain:
- \`gale/ffi/Cargo.toml\` sets \`lto = true\` for \`[profile.release]\` (fat LTO).
- \`gale/zephyr/CMakeLists.txt\` sets \`-Ccode-model=small\` for x86 (correct — Zephyr maps the kernel low).
- The precompiled \`core\` rustlib for \`x86_64-unknown-none\` was built with the target's default \`code-model=kernel\` and ships with embedded bitcode tagged that way.
- rustc fat-LTO loads \`core\`'s bitcode and tries to merge it with \`gale-ffi\`'s bitcode. LLVM's "Code Model" module flag is \`Error\`-level: 1 (small) and 2 (kernel) cannot coexist, so the bitcode load aborts.

Cortex-M doesn't trip on this because we don't override \`code-model\` on Cortex-M; the default matches the precompiled \`core\`.

## Fix

Switch x86 builds from the \`release\` profile to the existing \`release-lto\` profile (which has \`lto = false\`), but only when the cross-language-LTO upper block hasn't already set it. \`release-lto\` already \`inherits = "release"\` so all other tuning (\`opt-level=\"z\"\`, \`codegen-units=1\`, \`panic=\"abort\"\`, \`overflow-checks=true\`) is preserved.

Scoped inside \`if(CONFIG_X86)\` so Cortex-M is byte-identical to before — the merged-in PR #27 publication-relevant LTO numbers are not at risk.

\`\`\`diff
diff --git a/zephyr/CMakeLists.txt b/zephyr/CMakeLists.txt
@@ -183,6 +183,29 @@ if(CONFIG_X86)
     ...
+  if(GALE_CARGO_PROFILE_DIR STREQUAL "release")
+    set(GALE_CARGO_PROFILE_ARGS \"--profile\" \"release-lto\")
+    set(GALE_CARGO_PROFILE_DIR \"release-lto\")
+    message(STATUS \"Gale: x86 — using release-lto profile to avoid core bitcode/code-model mismatch\")
+  endif()
 endif()
\`\`\`

## Test plan

- [x] Reproduced the failure locally (rustc 1.95.0, x86_64-unknown-none target, with the exact CI feature set)
- [x] Confirmed fix resolves locally — same cargo invocation builds clean producing 10 MB libgale_ffi.a
- [x] Cortex-M cargo build (thumbv7m-none-eabi) still builds clean — change is \`if(CONFIG_X86)\`-scoped
- [ ] CI on this PR validates the three SMP tests now pass

Local repro / validation command (no Zephyr SDK needed):

\`\`\`
cd gale/ffi && env RUSTFLAGS=\"-Crelocation-model=static -Ccode-model=small\" \\
  GALE_MAX_SEMS=32 GALE_MAX_WAITERS=16 \\
  cargo build --profile release-lto --target x86_64-unknown-none \\
  --no-default-features \\
  --features sem,mutex,condvar,msgq,pipe,stack,timer,...,rbtree
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)