### PR TITLE
ci: migrate fuzz-smoke (12 targets) + sanitizers (3 modes) to smithy

### DIFF
--- a/.github/workflows/fuzz-smoke.yml
+++ b/.github/workflows/fuzz-smoke.yml
@@ -38,7 +38,7 @@ concurrency:
 jobs:
   fuzz:
     name: "${{ matrix.target }} (60s)"
-    runs-on: ubuntu-22.04
+    runs-on: [self-hosted, linux, x64, rust-cpu]
     timeout-minutes: 10
     strategy:
       fail-fast: false

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -42,8 +42,8 @@ concurrency:
 
 jobs:
   sanitize:
-    name: "${{ matrix.sanitizer }} (ubuntu-22.04)"
-    runs-on: ubuntu-22.04
+    name: "${{ matrix.sanitizer }} (rust-cpu)"
+    runs-on: [self-hosted, linux, x64, rust-cpu]
     timeout-minutes: 45
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Summary

First gale pass onto smithy self-hosted, deliberately small. Two
workflows whose steps are container-free and don't need any host
tooling smithy doesn't already ship:

  - `fuzz-smoke.yml` — 12-target matrix, 60s per target
  - `sanitizers.yml` — ASan / TSan / LSan, nightly Rust + rust-src

Both move to the `rust-cpu` class (12 G MemoryHigh, sccache
disabled today, plenty of compile capacity).

## Out of scope this PR (each gale workflow listed once for clarity)

| Workflow | Reason hosted stays |
|---|---|
| `bazel-tests` | Bazel not on smithy |
| `coverage` | container: vendor CI image |
| `engine-bench-*` (5 files) | container: vendor CI image |
| `formal-verification` (verus/kani/rocq) | Bazel + Nix + CBMC; toolchains role would need to ship them |
| `llvm-lto` | container: vendor CI image |
| `nightly` | container: vendor CI image |
| `renode-tests` | container: vendor CI image |
| `zephyr-tests` | container: vendor CI image |

The container: jobs are migrable via smithy's podman-docker compat
shim, but UNTESTED on these specific Zephyr / vendor images. Belongs
in a follow-up PR with a controlled validation, not a "flip + hope"
move.

## Expected win

Same as spar / rivet / kiln: queue elimination on the org-free
Actions tier dominates. fuzz-smoke and sanitizers both run real
nightly cargo work for minutes-scale, exactly the shape that
exposes runner queue waste.

## Test plan

- [ ] All 12 fuzz targets run on `rust-cpu` and finish green
- [ ] All 3 sanitizer modes run on `rust-cpu` and finish green
- [ ] No EACCES events in smithy's `journalctl -u smithy-trace-eacces.service`
- [ ] No "no space left on device" — TMPDIR fix should hold

## Rollback

Revert this commit; both workflows flip back to `ubuntu-22.04`.