### PR TITLE
fix(ci): pin nightly fuzz to x86_64-unknown-linux-gnu

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -109,9 +109,13 @@ jobs:
       - name: Run fuzz target for 3600s
         env:
           TARGET: ${{ matrix.target }}
+        # cargo-fuzz defaults to x86_64-unknown-linux-musl on Linux; libfuzzer-sys
+        # enables -Zsanitizer=address by default and rustc rejects ASan with a
+        # statically-linked musl libc. Pin to gnu, mirroring fuzz-smoke.yml.
         run: |
           mkdir -p fuzz/artifacts fuzz/corpus
           cargo +nightly fuzz run "${TARGET}" \
+            --target x86_64-unknown-linux-gnu \
             -- -max_total_time=3600 -print_final_stats=1
 
       - name: Upload corpus (always)


### PR DESCRIPTION
## Summary

Nightly has been red every night since 2026-05-04 — all 12 `fuzz-long` matrix targets failing with:

\`\`\`
error: sanitizer is incompatible with statically linked libc,
       disable it using \`-C target-feature=-crt-static\`
error[E0463]: can't find crate for \`core\`
note: the \`x86_64-unknown-linux-musl\` target may not be installed
\`\`\`

**Root cause.** \`cargo fuzz\` defaults to \`x86_64-unknown-linux-musl\` on Linux. libfuzzer-sys enables \`-Zsanitizer=address\` by default. ASan + statically-linked musl libc are incompatible.

**Why now.** Workflow added in \`894c98e\` (PR #21, 2026-04-24). Same-day follow-up \`1d7723a\` fixed `fuzz-smoke.yml` by pinning \`--target x86_64-unknown-linux-gnu\` but missed `nightly.yml`. Cron only fires at 03:00 UTC, so the regression silently sailed past until the first scheduled run on 2026-05-04 — 10 days unnoticed.

**Fix.** Mirror the proven \`fuzz-smoke.yml\` pattern. One-line change.

PR #35 (smithy-migration) is orthogonal — its diff only touches \`fuzz-smoke.yml\` + \`sanitizers.yml\`; this regression would persist after #35 lands.

## Test plan

- [ ] Manual dispatch of the Nightly workflow on this branch (\`gh workflow run nightly.yml --ref fix/nightly-fuzz-musl-target\`) to confirm the targeted-gnu build proceeds at least past the failing rustc step.
- [ ] Wait for the next scheduled nightly run after merge to confirm green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)