### PR TITLE
experiment(smp): SMP tests with NO Gale module — pure discriminator (do not merge)

### DIFF
--- a/.github/workflows/zephyr-tests.yml
+++ b/.github/workflows/zephyr-tests.yml
@@ -322,11 +322,13 @@ jobs:
           export ZEPHYR_BASE="${GITHUB_WORKSPACE}/zephyr-workspace/zephyr"
           export GALE_ROOT="${GITHUB_WORKSPACE}/gale"
           cd zephyr-workspace
-          west build -b qemu_x86_64 \
-            -s "zephyr/${TEST_PATH}" \
-            -- \
-            -DZEPHYR_EXTRA_MODULES="${GALE_ROOT}" \
-            -DOVERLAY_CONFIG="${GALE_ROOT}/zephyr/gale_overlay.conf;${GALE_ROOT}/zephyr/gale_smp_overlay.conf"
+          # EXPERIMENT (do not merge): omit -DZEPHYR_EXTRA_MODULES and
+          # -DOVERLAY_CONFIG so the SMP tests build vanilla Zephyr with
+          # no Gale module. PR #38 + #41 ruled out the three Gale SMP
+          # shim Kconfigs as the smp_mutex/smp_threads AP-startup hang
+          # source. This run answers the next discriminator: does the
+          # hang reproduce without Gale at all?
+          west build -b qemu_x86_64 -s "zephyr/${TEST_PATH}"
           timeout 300 west build -t run 2>&1 | tee test.log
           if grep -q "PROJECT EXECUTION SUCCESSFUL" test.log; then
             echo "PASS"


### PR DESCRIPTION
## Not for merge — diagnostic CI run only

PR #38 (\`SPINLOCK_VALIDATE=n\`) and PR #41 (all three SMP shims off) ruled out the Gale SMP-shim layer as the source of the \`smp_mutex\` / \`smp_threads\` AP-startup hang on \`qemu_x86_64\`. The bisect axis was wrong.

This branch removes \`-DZEPHYR_EXTRA_MODULES\` and \`-DOVERLAY_CONFIG\` from the \`qemu_x86_64\` SMP test build entirely (\`zephyr-tests.yml\`) — vanilla upstream Zephyr, no Gale at all.

**Reading the result:**

| outcome | reading |
|---|---|
| \`smp_mutex\` + \`smp_threads\` ✅ green | Gale is the cause — but in always-on Kconfigs (\`CONFIG_GALE_KERNEL_SEM\` / \`_TIMER\` / \`_SPINLOCK\` in \`gale_overlay.conf\`) or compile-time module source. Next bisect: toggle \`gale_overlay.conf\` options one at a time. |
| either still ❌ red | Hang is upstream of Gale: test itself, \`qemu_x86_64\` defconfig, or upstream Zephyr SMP boot. Right fix is documenting it in \`zephyr-tests.yml\`'s known-issue block, not in Gale. |

The branch breaks testing semantics for any other PR that depends on the SMP coverage. Close once the answer lands.