### PR TITLE
chore(zephyr): migrate fork base rc3 → v4.4.0 final

### DIFF
--- a/docs/research/heap-hardening-port-plan.md
+++ b/docs/research/heap-hardening-port-plan.md
@@ -6,7 +6,7 @@
 
 ## 1. Upstream feature inventory
 
-Upstream file: `/Users/r/git/pulseengine/z/zephyr/lib/heap/heap.c` (v4.4.0-rc3, 794 lines).
+Upstream file: `/Users/r/git/pulseengine/z/zephyr/lib/heap/heap.c` (v4.4.0, 794 lines; unchanged rc3→final).
 Header: `/Users/r/git/pulseengine/z/zephyr/lib/heap/heap.h` (350 lines).
 
 Level predicates are defined in `heap.h:23-30` as compile-time `#define`s that

--- a/docs/safety/upstream-drift-audit.md
+++ b/docs/safety/upstream-drift-audit.md
@@ -1,7 +1,9 @@
-# Upstream-Drift Audit: Gale Shims vs Zephyr v4.4.0-rc3
+# Upstream-Drift Audit: Gale Shims vs Zephyr v4.4.0
 
-Baseline: Zephyr fork merge-base 2026-03-09. Tip: `v4.4.0-rc3` (commit
-`6182bc08c9d`). Scope: C files replaced via `CONFIG_GALE_KERNEL_*` fork
+Baseline: Zephyr fork merge-base 2026-03-09. Tip: `v4.4.0` (commit
+`684c9e8f3`; rebased from `v4.4.0-rc3`/`6182bc08c9d` on 2026-05-29 — the
+rc3→final delta touched none of the files audited below, so the findings
+and severities are unchanged). Scope: C files replaced via `CONFIG_GALE_KERNEL_*` fork
 guards (21 in `kernel/CMakeLists.txt` + 1 in `lib/heap/CMakeLists.txt`).
 Gap example tracked in gh issue #15 (heap canary hardening missing).
 


### PR DESCRIPTION
## What

Migrates the gale Zephyr fork base from **v4.4.0-rc3 → v4.4.0 final**.

The `pulseengine/zephyr` branch `gale/sem-replacement` (tracked by every CI workflow via `west init --mr gale/sem-replacement`) was rebased from `v4.4.0-rc3` onto the `v4.4.0` final tag. This PR carries only the gale-repo doc bumps; the actual rebase lives on the fork.

## Rebase facts

- 7 gale patches (conditional sem/mutex/msgq/stack/pipe/heap, picolibc ld.lld fork, llvm toolchain shim) rebased **byte-identically** (`git range-diff` clean).
- rc3→final delta = 35 commits, **none touching gale's patched files** → zero conflicts.
- SDK requirement unchanged (`SDK_VERSION=1.0.1`, matches installed).
- Old rc3 tip preserved at `gale/sem-replacement-rc3` on the fork.

## Validation

- `qemu_cortex_m3` gale build: clean (FLASH 16.7 KB / RAM 16.5 KB).
- `nucleo_g474re` (silicon target) gale build: clean (FLASH 23.9 KB / RAM 17 KB).
- qemu smoke: boots `v4.4.0-7-g719cc4890346`, full RPM sweep 1000→10000, **0 drops**, no faults — exercises the `kernel/timer.c` k_timer-reuse fix new in final.
- The bump touches no verified Rust code; Verus/Rocq/Kani are unaffected and run on this PR.

## Notes for reviewers

- `kernel/timer.c` "k_timer re-use in handler" fix and the "Dumb→Simple" scheduler rename are the only behaviorally-relevant final-vs-rc3 kernel changes; both validated above.
- Silicon cycle baselines in the silicon PR were captured on rc3; re-validation on hardware recommended as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)