### PR TITLE
ci(nightly): build fuzz-long on gnu target (fixes all 12 nightly fuzz failures)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -109,9 +109,17 @@ jobs:
       - name: Run fuzz target for 3600s
         env:
           TARGET: ${{ matrix.target }}
+        # Force x86_64-unknown-linux-gnu: cargo-fuzz defaults to
+        # x86_64-unknown-linux-musl on Linux, whose statically-linked libc
+        # is incompatible with -Zsanitizer=address ("sanitizer is
+        # incompatible with statically linked libc, disable it using
+        # -C target-feature=-crt-static"). The GNU target has a dynamic
+        # libc and plays fine with ASan, which cargo-fuzz enables by
+        # default via libfuzzer-sys. (Matches fuzz-smoke.yml.)
         run: |
           mkdir -p fuzz/artifacts fuzz/corpus
           cargo +nightly fuzz run "${TARGET}" \
+            --target x86_64-unknown-linux-gnu \
             -- -max_total_time=3600 -print_final_stats=1
 
       - name: Upload corpus (always)


### PR DESCRIPTION
## What

All 12 `*_fuzz (1h)` jobs in the nightly have been failing at build:

```
error: sanitizer is incompatible with statically linked libc, disable it using `-C target-feature=-crt-static`
error[E0463]: can't find crate for `core` — the `x86_64-unknown-linux-musl` target may not be installed
```

`cargo-fuzz` defaults to `x86_64-unknown-linux-musl` on Linux; musl's statically-linked libc is incompatible with `-Zsanitizer=address` (which libfuzzer-sys enables by default). `fuzz-smoke.yml` already forces `--target x86_64-unknown-linux-gnu` for exactly this reason — `nightly.yml`'s fuzz-long job was simply missing the same flag.

## Fix

Add `--target x86_64-unknown-linux-gnu` to the nightly fuzz-long invocation, mirroring `fuzz-smoke.yml`.

## Notes

- **Pre-existing** — these failed identically on `9d8e9f8c` (before the v4.4.0 Zephyr migration) and `9c872cc6` (after). Not migration-related.
- Out of scope: `zephyr/cortex-m33 (mps2/an521)` also fails in the nightly; its log wasn't retrievable (blob TLS timeout) and it's a separate issue — left for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)