### PR TITLE
fix(smp): x86_64 SMP boot hang — gale spin_unlock_valid rejects the (0,0,0) early-boot owner

### DIFF
--- a/zephyr/gale_spinlock_validate.c
+++ b/zephyr/gale_spinlock_validate.c
@@ -69,10 +69,14 @@ bool z_spin_unlock_valid(struct k_spinlock *l)
 		return true;
 	}
 
-	if (thread_cpu == 0) {
-		return false;
-	}
-
+	/* NOTE: do NOT early-return false when thread_cpu == 0. During early
+	 * x86_64 CPU init, CPU 0 acquires locks with _current == NULL, so the
+	 * encoded owner is (0 | 0) == 0. Stock z_spin_unlock_valid treats that
+	 * as a valid match (0 == 0); an early `thread_cpu == 0 -> false` here
+	 * instead fails the __ASSERT in k_spin_unlock, whose assert_print ->
+	 * vprintk path re-takes spinlocks that re-fail validation -> infinite
+	 * recursion -> silent hang before the console is up. gale_spin_unlock_valid
+	 * already returns the correct result for the (0,0,0) case. */
 	return gale_spin_unlock_valid(thread_cpu,
 				      _current_cpu->id,
 				      (uintptr_t)_current) != 0;


### PR DESCRIPTION
## What
The `qemu_x86_64` SMP tests (`smp_semaphore`/`smp_mutex`/`smp_threads`) hung at boot with no console output — the long-standing `continue-on-error` "Gale shim interaction with x86_64 SMP init" issue. This fixes the hang.

## Root cause (reproduced locally + gdb backtrace)
During early x86_64 CPU init (`z_x86_cpu_init → z_loapic_enable → virt_region_init → bitarray set_clear_region`), CPU 0 takes a spinlock while `_current == NULL`. The encoded owner is `cpu_id | (uintptr_t)_current == 0 | 0 == 0`.

On unlock, **stock** `z_spin_unlock_valid` treats that as a valid match (`tcpu 0 == 0` → true). But the gale shim had an extra `if (thread_cpu == 0) return false;`, so it failed `__ASSERT(z_spin_unlock_valid(l))` in `k_spin_unlock`. The assert path (`assert_print → vprintk`) itself takes spinlocks whose validation **also** fails → **recursive assertion failure → stack recursion → silent hang** before the console is up.

## Fix
Drop the bogus early-return. `gale_spin_unlock_valid(0, 0, 0)` already returns the correct result (`0 == (0|0)` → valid), matching stock. The verified Rust was already correct — the bug was C-shim-only.

## Verification (local qemu_x86_64 SMP, Zephyr SDK x86_64-zephyr-elf)
- `smp_semaphore`: was HANG → now **PROJECT EXECUTION SUCCESSFUL (61/0)**.
- All three suites now get **past the boot hang**.

## Follow-up (separate, newly-exposed)
With the hang gone, `smp_threads` shows 9 thread-lifecycle subtest failures (stock: 0) and `smp_mutex` hangs *inside* `mutex_api` — distinct gale-SMP-correctness issues the boot hang was masking. Will file separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)