### PR TITLE
fix(rivet): resolve 3 duplicate-artifact-id collisions — validate FAIL→PASS

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"b9703d91-674b-4409-82ca-8c80975abd51","pid":64310,"procStart":"Fri May 29 19:25:36 2026","acquiredAt":1780113269841}

--- a/artifacts/safety_case.yaml
+++ b/artifacts/safety_case.yaml
@@ -17,7 +17,7 @@ artifacts:
 
   # ── Contexts ──────────────────────────────────────────────────────────────
 
-  - id: C-1
+  - id: CTX-1
     type: safety-context
     title: Target platform — ARM Cortex-M, no MMU
     status: approved
@@ -41,7 +41,7 @@ artifacts:
       - type: scopes
         target: G-1
 
-  - id: C-2
+  - id: CTX-2
     type: safety-context
     title: Zephyr RTOS v3.x kernel API compatibility
     status: approved

--- a/artifacts/verification.yaml
+++ b/artifacts/verification.yaml
@@ -4599,7 +4599,7 @@ artifacts:
   #    the loom concurrency harness (#22), the heap FULL-tier canary
   #    (#15 PR-4), and the LLVM LTO regression-guard (#10) ───────────
 
-  - id: FV-US-003
+  - id: FV-US-002
     type: sw-verification
     title: k_object flag-op delegation to verified userspace model
     status: approved
@@ -4714,7 +4714,7 @@ artifacts:
         target: FV-SEM-001
 
   # ── 2026-04-25 #9 batch 2: 10 RED FFI fns wired to verified models.
-  #    Same delegation pattern as FV-US-003 / FV-RB-002 from batch 1.
+  #    Same delegation pattern as FV-US-002 / FV-RB-002 from batch 1.
 
   - id: FV-KH-002
     type: sw-verification


### PR DESCRIPTION
## What

`rivet validate` was **FAIL (3 errors)** on duplicate artifact IDs — silent overwrites in the trace graph. All three are genuine ID-namespace collisions:

| dup ID | collision | fix |
|---|---|---|
| `C-1` / `C-2` | `safety-context` (safety_case.yaml) vs **`controller`** (stpa_controllers_ucas.yaml) | controllers own C-1/C-2 (heavily referenced by UCA `target:` links) → renamed the **safety-contexts** to `CTX-1`/`CTX-2` (CTX- was free; SC- is taken by system-constraints) |
| `FV-US-003` | two different `sw-verification`s in verification.yaml (Clippy-lint vs k_object-delegation) | the delegation verification renumbered to the free `FV-US-002` (+ its prose ref) |

## Result
- `rivet validate`: **FAIL (3 errors, 28 warnings) → PASS (30 warnings)**, **0 broken cross-refs**.
- No safety-relevant content changed — only the three colliding IDs (which were silently shadowing each other). The STPA controllers, system-constraints, and the first FV-US-003 keep their IDs; nothing referenced the renamed safety-contexts via links (verified — only a prose mention that was already about the controllers).

The remaining 30 warnings are lifecycle-coverage gaps (311 missing unit/integration/system verification links) — a separate traceability-audit task, not addressed here. The `variants/bindings.yaml` 'missing field name' warning is a pre-existing rivet variant-config schema mismatch (non-blocking).

🤖 Generated with [Claude Code](https://claude.com/claude-code)