### PR TITLE
plan(rivet): start the release roadmap — v0.1.0 = semaphore (depth-first)

### DIFF
--- a/artifacts/requirements.yaml
+++ b/artifacts/requirements.yaml
@@ -73,7 +73,7 @@ artifacts:
       initialization with count and limit, give (signal), take (wait),
       and reset.  Must maintain priority-ordered wait queue for blocked
       threads and never exhibit undefined behavior or arithmetic overflow.
-    tags: [sem, kernel]
+    tags: [sem, kernel, release-v0.1.0]
     fields:
       req-type: functional
       priority: must
@@ -101,7 +101,7 @@ artifacts:
       The semaphore count is always between 0 and limit inclusive.
       This is the fundamental invariant — it must hold after init, give,
       take, reset, and any interleaving of operations.
-    tags: [sem, invariant, asil-d]
+    tags: [sem, invariant, asil-d, release-v0.1.0]
     fields:
       req-type: safety
       priority: must
@@ -131,7 +131,7 @@ artifacts:
     description: >
       The semaphore limit is always strictly positive.
       Enforced by init rejecting limit == 0 with -EINVAL.
-    tags: [sem, invariant, asil-d]
+    tags: [sem, invariant, asil-d, release-v0.1.0]
     fields:
       req-type: safety
       priority: must
@@ -152,7 +152,7 @@ artifacts:
       if count < limit, count increments by 1 (GiveResult::Incremented).
       If count == limit, count is unchanged (GiveResult::Saturated).
       Maps to z_impl_k_sem_give lines 109-111 in kernel/sem.c.
-    tags: [sem, give, asil-d]
+    tags: [sem, give, asil-d, release-v0.1.0]
     fields:
       req-type: functional
       priority: must
@@ -176,7 +176,7 @@ artifacts:
       highest-priority (numerically lowest) waiting thread is woken with
       return value 0 (OK).  The count does not change.
       Maps to z_impl_k_sem_give lines 103-108 in kernel/sem.c.
-    tags: [sem, give, wake, asil-d]
+    tags: [sem, give, wake, asil-d, release-v0.1.0]
     fields:
       req-type: functional
       priority: must
@@ -197,7 +197,7 @@ artifacts:
       When take is called and count > 0, count decrements by 1 and
       returns 0 (OK).
       Maps to z_impl_k_sem_take lines 143-148 in kernel/sem.c.
-    tags: [sem, take, asil-d]
+    tags: [sem, take, asil-d, release-v0.1.0]
     fields:
       req-type: functional
       priority: must
@@ -219,7 +219,7 @@ artifacts:
       When take is called with K_NO_WAIT and count == 0, returns -EBUSY
       without modifying the semaphore.
       Maps to z_impl_k_sem_take lines 150-154 in kernel/sem.c.
-    tags: [sem, take, asil-d]
+    tags: [sem, take, asil-d, release-v0.1.0]
     fields:
       req-type: functional
       priority: must
@@ -239,7 +239,7 @@ artifacts:
       When take is called with a timeout and count == 0, the calling
       thread is blocked and inserted into the wait queue in priority order.
       Maps to z_impl_k_sem_take line 158 (z_pend_curr) in kernel/sem.c.
-    tags: [sem, take, blocking, asil-d]
+    tags: [sem, take, blocking, asil-d, release-v0.1.0]
     fields:
       req-type: functional
       priority: must
@@ -263,7 +263,7 @@ artifacts:
       Reset clears count to 0 and wakes every waiting thread with
       return value -EAGAIN.  Returns the number of threads woken.
       Maps to z_impl_k_sem_reset lines 166-192 in kernel/sem.c.
-    tags: [sem, reset, asil-d]
+    tags: [sem, reset, asil-d, release-v0.1.0]
     fields:
       req-type: functional
       priority: must
@@ -286,7 +286,7 @@ artifacts:
       or underflow.  Give at limit saturates; take at 0 returns error.
       The C code uses (count != limit) ? 1U : 0U pattern (line 110).
       Gale uses checked_add/saturating_sub.
-    tags: [sem, safety, overflow, asil-d]
+    tags: [sem, safety, overflow, asil-d, release-v0.1.0]
     fields:
       req-type: safety
       priority: must
@@ -306,7 +306,7 @@ artifacts:
       The wait queue maintains priority ordering (numerically lowest
       priority value = highest priority) at all times.  Threads are
       woken strictly in priority order.
-    tags: [sem, wait-queue, ordering, asil-d]
+    tags: [sem, wait-queue, ordering, asil-d, release-v0.1.0]
     fields:
       req-type: functional
       priority: must

--- a/docs/release-plan.md
+++ b/docs/release-plan.md
@@ -16,7 +16,7 @@ requirement in its scope is `verified`/`accepted` and its V is closed
 ```sh
 REL=release-v0.1.0
 total=$(rivet list --filter "(has-tag \"$REL\")" --format json | python3 -c 'import json,sys;print(json.load(sys.stdin)["count"])')
-done=$(rivet list  --filter "(and (has-tag \"$REL\") (in status \"verified\" \"accepted\"))" --format json | python3 -c 'import json,sys;print(json.load(sys.stdin)["count"])')
+done=$(rivet list  --filter "(and (has-tag \"$REL\") (or (= status \"verified\") (= status \"accepted\")))" --format json | python3 -c 'import json,sys;print(json.load(sys.stdin)["count"])')
 echo "$REL: $done / $total verified"
 ```
 

--- a/docs/release-plan.md
+++ b/docs/release-plan.md
@@ -1,0 +1,43 @@
+---
+title: gale release plan
+---
+# gale release plan (rivet-driven)
+
+Releases are scoped **in rivet** via a `release-vX.Y.Z` **tag** on the requirement
+artifacts in scope (rivet 0.15.0's `sw-req`/`system-req` schemas have no native
+`release:` field — see pulseengine/rivet issue on this; tags are the working
+mechanism and are queryable via `(has-tag …)`).
+
+**Readiness is a query, not an opinion.** A release is cuttable when every
+requirement in its scope is `verified`/`accepted` and its V is closed
+(`rivet validate` green for the scope).
+
+## Readiness burn-down (run anytime)
+```sh
+REL=release-v0.1.0
+total=$(rivet list --filter "(has-tag \"$REL\")" --format json | python3 -c 'import json,sys;print(json.load(sys.stdin)["count"])')
+done=$(rivet list  --filter "(and (has-tag \"$REL\") (in status \"verified\" \"accepted\"))" --format json | python3 -c 'import json,sys;print(json.load(sys.stdin)["count"])')
+echo "$REL: $done / $total verified"
+```
+
+## v0.1.0 — semaphore (depth-first)
+Scope = the semaphore primitive, taken end-to-end to `verified` before the next
+primitive starts. Tagged `release-v0.1.0`:
+
+- **Requirements (11):** `SWREQ-SEM-P01..P10` (the P1–P10 invariants/behaviours) + `SYSREQ-SEM-001`.
+- **Evidence already authored (not yet linked):** 5 detail-designs (`SWDD-SEM-*`),
+  1 arch (`SWARCH-SEM-001`), and **16 verifications** — `UV-SEM-001..005` (unit),
+  `IV-SEM-001/002` (integration), `SV-SEM-001` (system), `FV-SEM-001..003` +
+  `FV-WQ/PRI/THR/ERR-001` (formal), plus the silicon result (`k_sem_give` 907 cyc,
+  wasm-cross-LTO vs 471 LLVM-LTO).
+
+**Status: NOT cuttable yet.** All 11 reqs are `approved`, none `verified`. The
+gap is *linkage, not work*: the 16 sem verifications exist but aren't wired to the
+reqs via `verifies` links, so `rivet validate` reports the reqs unverified (part
+of the 311 lifecycle-coverage gaps). **v0.1 burn-down = wire the sem
+verifications → reqs, then drive status `approved → verified`** (a
+`traceability-audit` pass), after which v0.1 is cuttable.
+
+## Cadence
+Per-primitive depth-first: v0.1 sem → v0.2 mutex → … Each release ships when its
+scope's V is closed; unassigned primitives are backlog, not commitments.


### PR DESCRIPTION
## What

gale had **no release plan in rivet** — 0 of 924 artifacts carried any release scope, so the V-model trace couldn't drive or gate a roadmap. This starts it, depth-first per the release-planning model.

**v0.1.0 = the semaphore primitive**, taken end-to-end to `verified` before the next primitive begins.

- **Scope mechanism:** a `release-v0.1.0` **tag** on the 11 sem requirements (`SWREQ-SEM-P01..P10` + `SYSREQ-SEM-001`). rivet 0.15.0's `sw-req`/`system-req` schemas have **no native `release:` field** (the field is tolerated but not queryable by `--filter`), so tags are the working, queryable mechanism — filed as friction on pulseengine/rivet.
- **`docs/release-plan.md`:** the readiness burn-down one-liner (`rivet list --filter '(has-tag "release-vX")' … count`), the cuttability criterion, and the per-primitive cadence.

## Readiness (the query, not an opinion)
```
release-v0.1.0 (sem): 0 / 11 verified  →  NOT cuttable
```
All 11 reqs are `approved`, none `verified`. The gap is **linkage, not missing work**: 16 sem verifications already exist (`UV-SEM-001..005`, `IV-SEM-001/002`, `SV-SEM-001`, `FV-SEM/WQ/PRI/THR/ERR-*`, plus the 907-cyc silicon result) but aren't wired to the reqs via `verifies` links — so they show as unverified (part of the 311 lifecycle-coverage gaps). **v0.1 burn-down = wire those links, then drive `approved → verified`** (a traceability-audit pass), after which v0.1 is cuttable.

No artifact content changed — only `release-v0.1.0` tags added + a planning doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)