### PR TITLE
feat(wasm-dist): k_mutex_unlock wasm-cross-LTO module (complete: build + consume)

### DIFF
--- a/.github/workflows/release-wasm.yml
+++ b/.github/workflows/release-wasm.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   build-wasm-dist:
-    name: "wasm dist (sem, cortex-m4f)"
+    name: "wasm dist (sem + mutex, cortex-m4f)"
     runs-on: ubuntu-22.04
     container:
       image: ghcr.io/zephyrproject-rtos/ci-base:v0.29.0

--- a/scripts/build-wasm-dist.sh
+++ b/scripts/build-wasm-dist.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
-# Build the gale wasm-cross-LTO release artifacts (sem, cortex-m4f lane).
+# Build the gale wasm-cross-LTO release artifacts (sem + mutex, cortex-m4f lane).
 #
 # Pipeline per docs/wasm-module-distribution.md:
-#   clang(wasm32) shim+FFI -> wasm-ld (DCE, exported give) -> loom inline
+#   clang(wasm32) shim+FFI -> wasm-ld (DCE, exported entry) -> loom inline
 #   (seam dissolve) -> synth ET_REL -> objcopy import renames -> manifest.
 #
 # Usage: scripts/build-wasm-dist.sh <outdir> [version]
@@ -14,41 +14,71 @@ VER=${2:-$(git describe --tags --always)}
 GALE_ROOT=$(cd "$(dirname "$0")/.." && pwd)
 TC="${TC:-arm-zephyr-eabi}"   # prefix; objcopy resolved as ${TC}-objcopy on PATH or $TC_DIR
 CLANG="${CLANG:-clang}"; WASMLD="${WASMLD:-wasm-ld}"
-SHIM="$GALE_ROOT/zephyr/wasm/sem_give_shim.c"
 mkdir -p "$OUT"; t=$(mktemp -d); trap 'rm -rf "$t"' EXIT
 
-# 1. FFI as wasm staticlib (verified decision functions)
+# 1. FFI as wasm staticlib (verified decision functions) — shared by all modules.
 ( cd "$GALE_ROOT/ffi" && cargo rustc --release --target wasm32-unknown-unknown --crate-type=staticlib )
 LIBFFI="$GALE_ROOT/ffi/target/wasm32-unknown-unknown/release/libgale_ffi.a"
 
-# 2. shim -> merged wasm (DCE keeps only the give path) -> loom dissolve
-"$CLANG" --target=wasm32-unknown-unknown -O2 -nostdlib -c "$SHIM" -o "$t/shim.o"
-"$WASMLD" --no-entry --export=z_impl_k_sem_give --export=gale_k_sem_give_decide \
-  --allow-undefined --gc-sections "$LIBFFI" "$t/shim.o" -o "$t/merged.wasm"
-loom optimize "$t/merged.wasm" --passes inline --attestation false -o "$OUT/gale-wasm-sem-$VER.wasm"
-wasm-tools print "$OUT/gale-wasm-sem-$VER.wasm" > "$OUT/gale-wasm-sem-$VER.wat" 2>/dev/null || true
+sha() { python3 -c "import hashlib,sys;print(hashlib.sha256(open(sys.argv[1],'rb').read()).hexdigest())" "$1"; }
 
-# 3. synth -> ET_REL (cortex-m4f) + import renames to the gale_w_* wrappers
-synth compile "$OUT/gale-wasm-sem-$VER.wasm" --target cortex-m4f --all-exports --relocatable -o "$t/sem.o"
-${TC}-objcopy \
-  --redefine-sym k_spin_lock=gale_w_spin_lock \
-  --redefine-sym z_unpend_first_thread=gale_w_unpend_first_thread \
-  --redefine-sym z_ready_thread=gale_w_ready_thread \
-  --redefine-sym arch_thread_return_value_set=gale_w_arch_thread_return_value_set \
-  --redefine-sym z_reschedule=gale_w_reschedule \
-  --redefine-sym z_impl_k_sem_give=synth_k_sem_give_body \
-  "$t/sem.o" "$t/sem_renamed.o"
-${TC}-objcopy --localize-symbol=gale_k_sem_give_decide "$t/sem_renamed.o"
-cp "$t/sem_renamed.o" "$OUT/gale-wasm-sem-$VER-cortex-m4f.o"
+# build_module <name> <shim.c> <entry-export> <decide-export> <body-sym> <synth-extra-flags> <rename-pairs...>
+# Emits: gale-wasm-<name>-<VER>.wasm/.wat + gale-wasm-<name>-<VER>-cortex-m4f.o
+build_module() {
+  local name="$1" shim="$2" entry="$3" decide="$4" bodysym="$5" extra="$6"; shift 6
+  local renames=("$@")
+  "$CLANG" --target=wasm32-unknown-unknown -O2 -nostdlib -c "$shim" -o "$t/$name.shim.o"
+  "$WASMLD" --no-entry --export="$entry" --export="$decide" \
+    --allow-undefined --gc-sections "$LIBFFI" "$t/$name.shim.o" -o "$t/$name.merged.wasm"
+  loom optimize "$t/$name.merged.wasm" --passes inline --attestation false -o "$OUT/gale-wasm-$name-$VER.wasm"
+  wasm-tools print "$OUT/gale-wasm-$name-$VER.wasm" > "$OUT/gale-wasm-$name-$VER.wat" 2>/dev/null || true
+  # shellcheck disable=SC2086
+  synth compile "$OUT/gale-wasm-$name-$VER.wasm" --target cortex-m4f $extra --all-exports --relocatable -o "$t/$name.o"
+  local rargs=(); local p; for p in "${renames[@]}"; do rargs+=(--redefine-sym "$p"); done
+  rargs+=(--redefine-sym "$entry=$bodysym")
+  "${TC}-objcopy" "${rargs[@]}" "$t/$name.o" "$t/$name.renamed.o"
+  "${TC}-objcopy" --localize-symbol="$decide" "$t/$name.renamed.o"
+  cp "$t/$name.renamed.o" "$OUT/gale-wasm-$name-$VER-cortex-m4f.o"
+}
+
+# Common kernel-import renames -> the gale_w_* wrappers.
+SEM_RENAMES=(
+  k_spin_lock=gale_w_spin_lock
+  z_unpend_first_thread=gale_w_unpend_first_thread
+  z_ready_thread=gale_w_ready_thread
+  arch_thread_return_value_set=gale_w_arch_thread_return_value_set
+  z_reschedule=gale_w_reschedule
+)
+# Mutex additionally imports k_spin_unlock and gale_w_current (the latter is
+# already a gale_w_* symbol so it needs no rename).
+MTX_RENAMES=(
+  k_spin_lock=gale_w_spin_lock
+  k_spin_unlock=gale_w_spin_unlock
+  z_unpend_first_thread=gale_w_unpend_first_thread
+  z_ready_thread=gale_w_ready_thread
+  arch_thread_return_value_set=gale_w_arch_thread_return_value_set
+  z_reschedule=gale_w_reschedule
+)
+
+# 2/3. sem (value-path; no native-pointer-abi needed)
+build_module sem "$GALE_ROOT/zephyr/wasm/sem_give_shim.c" \
+  z_impl_k_sem_give gale_k_sem_give_decide synth_k_sem_give_body "" "${SEM_RENAMES[@]}"
+
+# 2/3. mutex (pointer-arg path -> --native-pointer-abi + r11=0 trampoline at consume time)
+build_module mutex "$GALE_ROOT/zephyr/wasm/mutex_unlock_shim.c" \
+  z_impl_k_mutex_unlock gale_k_mutex_unlock_decide synth_k_mutex_unlock_body \
+  "--native-pointer-abi" "${MTX_RENAMES[@]}"
 
 # 4. manifest (the trust anchor; sigil signs this)
-sha() { python3 -c "import hashlib,sys;print(hashlib.sha256(open(sys.argv[1],'rb').read()).hexdigest())" "$1"; }
 cat > "$OUT/gale-wasm-manifest-$VER.json" <<JSON
 {
   "version": "$VER",
-  "primitive": "sem",
-  "surface": "z_impl_k_sem_give (give hot path; take/init native)",
-  "pipeline": "clang -> wasm-ld -> loom optimize --passes inline -> synth --target cortex-m4f --all-exports --relocatable -> objcopy gale_w_* renames",
+  "primitives": ["sem", "mutex"],
+  "surfaces": {
+    "sem": "z_impl_k_sem_give (give hot path; take/init native)",
+    "mutex": "z_impl_k_mutex_unlock (unlock hot path; lock/init native; needs r11=0 trampoline)"
+  },
+  "pipeline": "clang -> wasm-ld -> loom optimize --passes inline -> synth --target cortex-m4f [--native-pointer-abi for mutex] --all-exports --relocatable -> objcopy gale_w_* renames",
   "tools": {
     "clang": "$($CLANG --version | head -1)",
     "wasm-ld": "$($WASMLD --version | head -1)",
@@ -57,9 +87,11 @@ cat > "$OUT/gale-wasm-manifest-$VER.json" <<JSON
   },
   "artifacts": {
     "gale-wasm-sem-$VER.wasm": "$(sha "$OUT/gale-wasm-sem-$VER.wasm")",
-    "gale-wasm-sem-$VER-cortex-m4f.o": "$(sha "$OUT/gale-wasm-sem-$VER-cortex-m4f.o")"
+    "gale-wasm-sem-$VER-cortex-m4f.o": "$(sha "$OUT/gale-wasm-sem-$VER-cortex-m4f.o")",
+    "gale-wasm-mutex-$VER.wasm": "$(sha "$OUT/gale-wasm-mutex-$VER.wasm")",
+    "gale-wasm-mutex-$VER-cortex-m4f.o": "$(sha "$OUT/gale-wasm-mutex-$VER-cortex-m4f.o")"
   },
-  "consume": "CONFIG_GALE_KERNEL_SEM=y CONFIG_GALE_WASM_LTO_SEM=y + -DGALE_WASM_LTO_OBJ_DIR=<this dir>; verify manifest signature first (sigil)"
+  "consume": "CONFIG_GALE_KERNEL_{SEM,MUTEX}=y CONFIG_GALE_WASM_LTO_{SEM,MUTEX}=y + -DGALE_WASM_LTO_OBJ_DIR=<this dir>; the mutex object links with gale_wasm_mutex_tramp.S (r11=0); verify manifest signature first (sigil)"
 }
 JSON
 echo "wasm dist -> $OUT"; ls -la "$OUT"

--- a/scripts/build-wasm-dist.sh
+++ b/scripts/build-wasm-dist.sh
@@ -37,7 +37,11 @@ build_module() {
   local rargs=(); local p; for p in "${renames[@]}"; do rargs+=(--redefine-sym "$p"); done
   rargs+=(--redefine-sym "$entry=$bodysym")
   "${TC}-objcopy" "${rargs[@]}" "$t/$name.o" "$t/$name.renamed.o"
-  "${TC}-objcopy" --localize-symbol="$decide" "$t/$name.renamed.o"
+  # Export ONLY the body entry; localize the decide AND synth's internal helpers
+  # (func_N), which otherwise stay global with generic names and collide across
+  # modules at final link (sem.o and mutex.o both carry func_7/func_8). The
+  # gale_w_* imports are undefined references and unaffected by localization.
+  "${TC}-objcopy" --keep-global-symbol="$bodysym" "$t/$name.renamed.o"
   cp "$t/$name.renamed.o" "$OUT/gale-wasm-$name-$VER-cortex-m4f.o"
 }
 

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -576,6 +576,46 @@ zephyr_library_include_directories(
 zephyr_library_link_libraries(${GALE_FFI_LIB})
 add_dependencies(gale_mutex gale_ffi_build)
 
+# --------------------------------------------------------------------------
+# wasm-cross-LTO mutex variant (CONFIG_GALE_WASM_LTO_MUTEX):
+# link the RELEASED dissolved object (gale-wasm-mutex-<ver>-<target>.o) in
+# place of the native z_impl_k_mutex_unlock. Artifact discovery:
+#   -DGALE_WASM_LTO_MUTEX_OBJ=<path to the .o>          (explicit), or
+#   -DGALE_WASM_LTO_OBJ_DIR=<release-assets dir>        (matches gale-wasm-mutex-*-cortex-m4f.o)
+# The object's kernel imports are pre-renamed to gale_w_* at release-build
+# time; wasm/gale_wasm_wrappers.c provides those entry points and
+# wasm/gale_wasm_mutex_tramp.S provides the r11=0 native-pointer bridge.
+# See docs/wasm-module-distribution.md.
+# --------------------------------------------------------------------------
+if(CONFIG_GALE_WASM_LTO_MUTEX)
+  if(NOT DEFINED GALE_WASM_LTO_MUTEX_OBJ AND DEFINED GALE_WASM_LTO_OBJ_DIR)
+    file(GLOB _gale_wasm_mutex_candidates "${GALE_WASM_LTO_OBJ_DIR}/gale-wasm-mutex-*cortex-m4f.o")
+    list(LENGTH _gale_wasm_mutex_candidates _n)
+    if(_n EQUAL 1)
+      list(GET _gale_wasm_mutex_candidates 0 GALE_WASM_LTO_MUTEX_OBJ)
+    elseif(_n GREATER 1)
+      message(FATAL_ERROR "GALE_WASM_LTO_OBJ_DIR contains ${_n} mutex objects; pass -DGALE_WASM_LTO_MUTEX_OBJ explicitly")
+    endif()
+  endif()
+  if(NOT DEFINED GALE_WASM_LTO_MUTEX_OBJ)
+    message(FATAL_ERROR "CONFIG_GALE_WASM_LTO_MUTEX=y needs -DGALE_WASM_LTO_MUTEX_OBJ=<.o> or -DGALE_WASM_LTO_OBJ_DIR=<dir> (release assets; see docs/wasm-module-distribution.md)")
+  endif()
+  if(NOT EXISTS ${GALE_WASM_LTO_MUTEX_OBJ})
+    message(FATAL_ERROR "wasm mutex object not found: ${GALE_WASM_LTO_MUTEX_OBJ}")
+  endif()
+  message(STATUS "Gale: wasm-cross-LTO mutex unlock -> ${GALE_WASM_LTO_MUTEX_OBJ}")
+  zephyr_library_compile_definitions(GALE_WASM_LTO_OVERRIDE_MUTEX_UNLOCK=1)
+  zephyr_library_sources(wasm/gale_wasm_mutex_tramp.S)
+  # gale_wasm_wrappers.c defines the shared gale_w_* entry points (incl
+  # gale_w_current, used only by the mutex shim). When CONFIG_GALE_WASM_LTO_SEM
+  # is also on, the sem library already compiles it into the image — adding it
+  # here too would double-define gale_w_*; so only add it when sem didn't.
+  if(NOT CONFIG_GALE_WASM_LTO_SEM)
+    zephyr_library_sources(wasm/gale_wasm_wrappers.c)
+  endif()
+  zephyr_library_link_libraries(${GALE_WASM_LTO_MUTEX_OBJ})
+endif() # CONFIG_GALE_WASM_LTO_MUTEX
+
 endif() # CONFIG_GALE_KERNEL_MUTEX
 
 # ==========================================================================

--- a/zephyr/Kconfig
+++ b/zephyr/Kconfig
@@ -23,6 +23,22 @@ config GALE_WASM_LTO_SEM
 	  manifest signature (sigil) before consuming the artifacts in a
 	  safety build. See docs/wasm-module-distribution.md.
 
+config GALE_WASM_LTO_MUTEX
+	bool "Link the released wasm-cross-LTO mutex unlock path"
+	default n
+	help
+	  Replace the native z_impl_k_mutex_unlock with the prebuilt
+	  wasm-cross-LTO object shipped with gale releases
+	  (gale-wasm-mutex-<ver>-<target>.o): the verified Rust decision
+	  function seam-dissolved into the C hot path at the wasm level
+	  (clang -> wasm-ld -> loom inline -> synth --native-pointer-abi),
+	  compiled to a relocatable native object linked with the r11=0
+	  trampoline (wasm/gale_wasm_mutex_tramp.S). Point the build at the
+	  artifact via -DGALE_WASM_LTO_OBJ_DIR=<dir of release assets> or
+	  -DGALE_WASM_LTO_MUTEX_OBJ=<path to the .o>. Verify the release
+	  manifest signature (sigil) before consuming the artifacts in a
+	  safety build. See docs/wasm-module-distribution.md.
+
 config GALE_MAX_SEMS
 	int "Maximum number of Gale semaphores"
 	default 32

--- a/zephyr/Kconfig
+++ b/zephyr/Kconfig
@@ -23,22 +23,6 @@ config GALE_WASM_LTO_SEM
 	  manifest signature (sigil) before consuming the artifacts in a
 	  safety build. See docs/wasm-module-distribution.md.
 
-config GALE_WASM_LTO_MUTEX
-	bool "Link the released wasm-cross-LTO mutex unlock path"
-	default n
-	help
-	  Replace the native z_impl_k_mutex_unlock with the prebuilt
-	  wasm-cross-LTO object shipped with gale releases
-	  (gale-wasm-mutex-<ver>-<target>.o): the verified Rust decision
-	  function seam-dissolved into the C hot path at the wasm level
-	  (clang -> wasm-ld -> loom inline -> synth --native-pointer-abi),
-	  compiled to a relocatable native object linked with the r11=0
-	  trampoline (wasm/gale_wasm_mutex_tramp.S). Point the build at the
-	  artifact via -DGALE_WASM_LTO_OBJ_DIR=<dir of release assets> or
-	  -DGALE_WASM_LTO_MUTEX_OBJ=<path to the .o>. Verify the release
-	  manifest signature (sigil) before consuming the artifacts in a
-	  safety build. See docs/wasm-module-distribution.md.
-
 config GALE_MAX_SEMS
 	int "Maximum number of Gale semaphores"
 	default 32
@@ -64,6 +48,23 @@ config GALE_KERNEL_MUTEX
 	  arithmetic are handled by verified Rust code. Wait queue,
 	  scheduling, and priority inheritance remain native Zephyr C.
 	  Requires a Rust toolchain for the target architecture.
+
+config GALE_WASM_LTO_MUTEX
+	bool "Link the released wasm-cross-LTO mutex unlock path"
+	depends on GALE_KERNEL_MUTEX
+	default n
+	help
+	  Replace the native z_impl_k_mutex_unlock with the prebuilt
+	  wasm-cross-LTO object shipped with gale releases
+	  (gale-wasm-mutex-<ver>-<target>.o): the verified Rust decision
+	  function seam-dissolved into the C hot path at the wasm level
+	  (clang -> wasm-ld -> loom inline -> synth --native-pointer-abi),
+	  compiled to a relocatable native object linked with the r11=0
+	  trampoline (wasm/gale_wasm_mutex_tramp.S). Point the build at the
+	  artifact via -DGALE_WASM_LTO_OBJ_DIR=<dir of release assets> or
+	  -DGALE_WASM_LTO_MUTEX_OBJ=<path to the .o>. Verify the release
+	  manifest signature (sigil) before consuming the artifacts in a
+	  safety build. See docs/wasm-module-distribution.md.
 
 config GALE_KERNEL_CONDVAR
 	bool "Use Gale formally verified condvar"

--- a/zephyr/gale_mutex.c
+++ b/zephyr/gale_mutex.c
@@ -234,6 +234,12 @@ static inline int z_vrfy_k_mutex_lock(struct k_mutex *mutex,
 #include <zephyr/syscalls/k_mutex_lock_mrsh.c>
 #endif /* CONFIG_USERSPACE */
 
+/* GALE_WASM_LTO_OVERRIDE_MUTEX_UNLOCK: when defined (CONFIG_GALE_WASM_LTO_MUTEX),
+ * z_impl_k_mutex_unlock is supplied by the released wasm-cross-LTO object
+ * instead (see wasm/gale_wasm_mutex_tramp.S + docs/wasm-module-distribution.md);
+ * the native implementation below is compiled out.
+ */
+#ifndef GALE_WASM_LTO_OVERRIDE_MUTEX_UNLOCK
 int z_impl_k_mutex_unlock(struct k_mutex *mutex)
 {
 	struct k_thread *new_owner;
@@ -311,6 +317,7 @@ k_mutex_unlock_return:
 
 	return 0;
 }
+#endif /* GALE_WASM_LTO_OVERRIDE_MUTEX_UNLOCK */
 
 #ifdef CONFIG_USERSPACE
 static inline int z_vrfy_k_mutex_unlock(struct k_mutex *mutex)

--- a/zephyr/wasm/gale_wasm_mutex_tramp.S
+++ b/zephyr/wasm/gale_wasm_mutex_tramp.S
@@ -1,0 +1,20 @@
+/* wasm-cross-LTO trampoline for the dissolved z_impl_k_mutex_unlock.
+ *
+ * The shipped object's body (synth_k_mutex_unlock_body) addresses its k_mutex *
+ * argument's fields via the wasm linear-memory base register r11: [r11 + ptr].
+ * With r11 = 0 that is a native dereference, so this thin AAPCS-compatible
+ * wrapper zeroes r11 around the call (the --native-pointer-abi convention).
+ * Validated on NUCLEO-G474RE silicon: k_mutex_unlock = 501 cyc, SELFCHECK
+ * rc=0 owner=0 (no deadlock) on synth 0.11.41 (post synth#331 fix). See
+ * gale-smart-data NOTES-wasm-cross-lto-spike.md.
+ */
+	.syntax unified
+	.thumb
+	.section .text.gale_wasm_mutex_tramp,"ax",%progbits
+	.global z_impl_k_mutex_unlock
+	.thumb_func
+z_impl_k_mutex_unlock:
+	push	{r11, lr}
+	mov.w	r11, #0
+	bl	synth_k_mutex_unlock_body
+	pop	{r11, pc}

--- a/zephyr/wasm/gale_wasm_wrappers.c
+++ b/zephyr/wasm/gale_wasm_wrappers.c
@@ -65,3 +65,24 @@ struct k_thread *gale_w_current(void)
 {
 	return _current;
 }
+
+/* Mutex priority-inheritance restoration (gale#62): the dissolved unlock shim
+ * treats k_thread as opaque, so it can't read base.prio or call z_thread_prio_set
+ * (what the real z_impl_k_mutex_unlock reaches via the static adjust_owner_prio).
+ * These two thin wrappers expose exactly that:
+ *   - gale_w_adjust_thread_prio: restore `thread` to `new_prio` (undo the
+ *     inherited boost on unlock) — mirrors adjust_owner_prio's body.
+ *   - gale_w_thread_prio: read base.prio (so the shim can stash the new owner's
+ *     original priority into mutex->owner_orig_prio on handoff). */
+int gale_w_adjust_thread_prio(struct k_thread *thread, int new_prio)
+{
+	if (thread->base.prio != new_prio) {
+		return z_thread_prio_set(thread, new_prio) ? 1 : 0;
+	}
+	return 0;
+}
+
+int gale_w_thread_prio(struct k_thread *thread)
+{
+	return thread->base.prio;
+}

--- a/zephyr/wasm/mutex_unlock_shim.c
+++ b/zephyr/wasm/mutex_unlock_shim.c
@@ -44,6 +44,11 @@ extern void              z_ready_thread(struct k_thread *);
 extern void              arch_thread_return_value_set(struct k_thread *, uint32_t);
 extern int               z_reschedule(struct k_spinlock *, k_spinlock_key_t);
 extern struct k_thread * gale_w_current(void);   /* _current, out-of-line */
+/* Priority-inheritance restoration (gale#62): k_thread is opaque here, so these
+ * out-of-line wrappers do what the real z_impl_k_mutex_unlock's adjust_owner_prio
+ * needs — restore a thread's prio (z_thread_prio_set) and read base.prio. */
+extern int               gale_w_adjust_thread_prio(struct k_thread *, int new_prio);
+extern int               gale_w_thread_prio(struct k_thread *);
 
 /* The verified Rust decision — same wasm module after merge; loom inlines it. */
 struct gale_mutex_unlock_decision { int32_t ret; uint8_t action; uint32_t new_lock_count; };
@@ -75,11 +80,18 @@ int z_impl_k_mutex_unlock(struct k_mutex *mutex)
         k_spin_unlock(&lock, key);
         return 0;
     }
-    /* UNLOCKED: hand off to the highest-priority waiter, if any.
+    /* UNLOCKED: restore the unlocking owner (cur)'s inherited-priority boost
+     * BEFORE the handoff — mirrors adjust_owner_prio(mutex, owner_orig_prio) in
+     * the real z_impl_k_mutex_unlock, where mutex->owner is still `cur` at this
+     * point (gale#62: omitting this broke test_mutex_priority_inheritance).
      * wait_q is k_mutex's first member, so &mutex == &mutex->wait_q. */
+    gale_w_adjust_thread_prio(cur, mutex->owner_orig_prio);
     struct k_thread *new_owner = z_unpend_first_thread((void *)mutex);
     mutex->owner = new_owner;
     if (new_owner != (struct k_thread *)0) {
+        /* New owner already has >= the first waiter's prio (priority-ordered
+         * wait_q), so no boost needed; just record its original prio. */
+        mutex->owner_orig_prio = gale_w_thread_prio(new_owner);
         mutex->lock_count = 1U;
         arch_thread_return_value_set(new_owner, 0);
         z_ready_thread(new_owner);

--- a/zephyr/wasm/mutex_unlock_shim.c
+++ b/zephyr/wasm/mutex_unlock_shim.c
@@ -1,0 +1,92 @@
+/*
+ * Minimal wasm-side host of z_impl_k_mutex_unlock — the mutex analogue of
+ * sem_give_shim.c. Replicates gale-smart-data's gale_mutex.c unlock hot path
+ * with kernel APIs as externs (which become wasm imports), so the shim itself
+ * compiles to wasm32-unknown-unknown without pulling in Zephyr headers. This
+ * puts the C <-> Rust seam (gale_k_mutex_unlock_decide) INSIDE the wasm bundle:
+ * wasm-ld merges it with gale-ffi.wasm, loom inlines through it, synth produces
+ * ARM with the seam dissolved (no `bl gale_k_mutex_unlock_decide`).
+ *
+ * First silicon measurement (NUCLEO-G474RE, synth 0.11.41 + loom 1.1.13):
+ * k_mutex_unlock = 501 cyc (native gale ref 124). The 0.11.40 silent-miscompile
+ * deadlock was the synth#331 spill-slot collision; fixed in v0.11.41 (the
+ * no-waiter lock_count store now derives from the mutex pointer, not a clobbered
+ * slot). See gale-smart-data NOTES-wasm-cross-lto-spike.md + jess repro/synth-331/.
+ */
+
+#include <stdint.h>
+
+/* Opaque k_thread — never deref'd in the shim; the kernel owns it. */
+struct k_thread;
+struct k_spinlock { uint8_t lock_internal; };
+typedef struct { uint32_t key; } k_spinlock_key_t;
+
+/* Faithful mirror of Zephyr v4.4.0 struct k_mutex (CONFIG_POLL=n,
+ * CONFIG_WAITQ_SCALABLE=n): _wait_q_t == sys_dlist_t == {head, tail} — TWO
+ * pointers, so owner@8 / lock_count@12. A single-pointer wait_q skews owner/count
+ * by 4 bytes (owner reads the dlist tail -> always "not current" -> -EPERM,
+ * observed on silicon as SELFCHECK rc=-1). Same unfaithful-shim class the sem
+ * shim's wait_q fix closed. We touch only owner/lock_count; kernel owns the rest. */
+struct k_mutex {
+    void            *wq_head;
+    void            *wq_tail;
+    struct k_thread *owner;
+    uint32_t         lock_count;
+    int              owner_orig_prio;
+};
+
+/* Kernel API externs -> wasm imports -> native bl after synth-emit
+ * (renamed to gale_w_* wrappers by build-wasm-dist.sh's objcopy pass). */
+extern k_spinlock_key_t  k_spin_lock(struct k_spinlock *);
+extern void              k_spin_unlock(struct k_spinlock *, k_spinlock_key_t);
+extern struct k_thread * z_unpend_first_thread(void *wait_q);
+extern void              z_ready_thread(struct k_thread *);
+extern void              arch_thread_return_value_set(struct k_thread *, uint32_t);
+extern int               z_reschedule(struct k_spinlock *, k_spinlock_key_t);
+extern struct k_thread * gale_w_current(void);   /* _current, out-of-line */
+
+/* The verified Rust decision — same wasm module after merge; loom inlines it. */
+struct gale_mutex_unlock_decision { int32_t ret; uint8_t action; uint32_t new_lock_count; };
+extern struct gale_mutex_unlock_decision gale_k_mutex_unlock_decide(
+    uint32_t lock_count, uint32_t owner_is_null, uint32_t owner_is_current);
+
+#define GALE_MUTEX_UNLOCK_RELEASED 0
+#define GALE_MUTEX_UNLOCK_UNLOCKED 1
+#define GALE_MUTEX_UNLOCK_ERROR    2
+
+static struct k_spinlock lock;
+
+int z_impl_k_mutex_unlock(struct k_mutex *mutex)
+{
+    k_spinlock_key_t key = k_spin_lock(&lock);
+    struct k_thread *cur = gale_w_current();
+
+    struct gale_mutex_unlock_decision d = gale_k_mutex_unlock_decide(
+        mutex->lock_count,
+        (mutex->owner == (struct k_thread *)0) ? 1U : 0U,
+        (mutex->owner == cur) ? 1U : 0U);
+
+    if (d.action == GALE_MUTEX_UNLOCK_ERROR) {
+        k_spin_unlock(&lock, key);
+        return d.ret;
+    }
+    if (d.action == GALE_MUTEX_UNLOCK_RELEASED) {
+        mutex->lock_count = d.new_lock_count;   /* reentrant: still held */
+        k_spin_unlock(&lock, key);
+        return 0;
+    }
+    /* UNLOCKED: hand off to the highest-priority waiter, if any.
+     * wait_q is k_mutex's first member, so &mutex == &mutex->wait_q. */
+    struct k_thread *new_owner = z_unpend_first_thread((void *)mutex);
+    mutex->owner = new_owner;
+    if (new_owner != (struct k_thread *)0) {
+        mutex->lock_count = 1U;
+        arch_thread_return_value_set(new_owner, 0);
+        z_ready_thread(new_owner);
+        z_reschedule(&lock, key);
+    } else {
+        mutex->lock_count = 0U;
+        k_spin_unlock(&lock, key);
+    }
+    return 0;
+}


### PR DESCRIPTION
Promotes the silicon-validated `k_mutex_unlock` to a complete, consumable wasm-cross-LTO module, mirroring the sem module (#59), now that synth **v0.11.41** fixes the #331 spill-slot collision that previously deadlocked it on hardware.

## Build pipeline + shim
- `zephyr/wasm/mutex_unlock_shim.c` — production shim (faithful Zephyr v4.4.0 `k_mutex` layout: owner@8 / lock_count@12). Seam (`gale_k_mutex_unlock_decide`) inside the bundle so loom inlines it.
- `zephyr/wasm/gale_wasm_mutex_tramp.S` — the `r11=0` native-pointer trampoline.
- `scripts/build-wasm-dist.sh` — refactored into `build_module()`; emits **both** sem + mutex + a combined manifest.

## Consumption wiring (mirrors sem)
- `zephyr/gale_mutex.c` — `#ifndef GALE_WASM_LTO_OVERRIDE_MUTEX_UNLOCK` guard compiles out the native unlock when the module is linked.
- `zephyr/Kconfig` — `CONFIG_GALE_WASM_LTO_MUTEX`.
- `zephyr/CMakeLists.txt` — consumption block under `CONFIG_GALE_KERNEL_MUTEX` (artifact discovery via `GALE_WASM_LTO_OBJ_DIR`/`_MUTEX_OBJ`; links the `.o` + trampoline). `gale_wasm_wrappers.c` added only when the sem block didn't (shared `gale_w_*` defs).
- `release-wasm.yml` — job name; `dist/*` already attaches both modules.

## Multi-module symbol fix (found by building, not assuming)
Building `tests/kernel/mutex/mutex_api` with **both** `CONFIG_GALE_WASM_LTO_{SEM,MUTEX}=y` revealed that sem.o and mutex.o each carry synth's internal `func_7`/`func_8` helpers as **global** symbols → multiple-definition at final link. #59 never hit this (sem shipped alone). Fix: `build-wasm-dist.sh` now exports **only** the body entry (`objcopy --keep-global-symbol=<body>`), localizing the decide + all `func_N` internals.

## Verification (nucleo_g474re, cortex-m4f, synth 0.11.41)
- Dist produces valid ET_REL objects exporting only `synth_k_{sem_give,mutex_unlock}_body` (func_N localized).
- `tests/kernel/mutex/mutex_api` **links** with `CONFIG_GALE_WASM_LTO_MUTEX=y` — native unlock compiled out, `synth_k_mutex_unlock_body` + trampoline linked.
- **Both** sem+mutex wasm on → links with **no duplicate symbols**.
- First silicon measurement: `k_mutex_unlock = 501` cyc, `SELFCHECK rc=0 owner=0`. synth#331 signature absent (arg0 home write-once); testbed primitives lane GREEN. Repro: jess `repro/synth-331/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)