### PR TITLE
fix(nightly): cortex-m33 board target mps2/an521 → mps2/an521/cpu0 (4.4.0 dual-cluster)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -7,7 +7,7 @@
 #   - kani-extended: re-runs Kani with higher unwind/object bits for
 #     deeper bounded model checking.
 #   - fuzz-long:     each cargo-fuzz target for 1h (3600s).
-#   - zephyr-qemu-matrix: Cortex-M33 (mps2/an521) and R5 (qemu_cortex_r5).
+#   - zephyr-qemu-matrix: Cortex-M33 (mps2/an521/cpu0) and R5 (qemu_cortex_r5).
 #     M3 is covered on every PR via zephyr-tests.yml; M4F is Renode-only
 #     since there is no upstream QEMU board for Cortex-M4F with FPU.
 
@@ -151,7 +151,7 @@ jobs:
       matrix:
         include:
           - arch: cortex-m33
-            board: mps2/an521
+            board: mps2/an521/cpu0
             rust_target: thumbv8m.main-none-eabi
             sdk_target: arm-zephyr-eabi
             test_path: tests/kernel/semaphore/semaphore


### PR DESCRIPTION
## Problem
The nightly **`zephyr/cortex-m33 (mps2/an521)`** job has been **red every run** (at least the last 8 nights) and no one had triaged it. The `precondition_erasure` cancel in those runs is just fail-fast fallout from this job.

## Root cause (measured, not guessed)
`west build -b mps2/an521` fails at CMake configure:
```
CMake Error at .../zephyr/cmake/modules/boards.cmake:281 (message):
  Board qualifiers `an521` for board `mps2` not found.  Please specify a valid board target.
-- Configuring incomplete, errors occurred!
##[error]Test suite failed on mps2/an521
```
The workspace pulls `pulseengine/zephyr@gale/sem-replacement`, which is now rebased to **Zephyr v4.4.0** (`VERSION: 4.4.0`). In that tree, AN521 was restructured into a **dual-cluster SoC** — the board files are now `mps2_an521_cpu0.{dts,yaml}`, `mps2_an521_cpu1.*`, and `mps2_an521_cpu0_ns.*`, with `mps2_an521-common.dtsi`. The bare `mps2/an521` target no longer resolves; the canonical identifier (from the fork's `boards/arm/mps2/mps2_an521_cpu0.yaml`) is:
```
identifier: mps2/an521/cpu0
```
`cortex-r5 (qemu_cortex_r5)` uses an old-style board name, so only the M33 leg was affected.

## Fix
Point the nightly M33 leg at the valid 4.4.0 target **`mps2/an521/cpu0`** (secure cpu0 cluster — the standard kernel-test target). One-line matrix change + the doc comment. Blast radius is just `nightly.yml` (only file in the repo referencing `mps2/an521`).

## Kill-criterion
This is wrong if the next nightly's M33 leg still fails at CMake configure with a board-qualifier error. Expected: it gets past configure and runs the semaphore suite under QEMU.

🤖 Generated with [Claude Code](https://claude.com/claude-code)