### PR TITLE
feat(wasm-dist): k_msgq_put wasm-cross-LTO module (complete: build + consume)

### DIFF
--- a/.github/workflows/release-wasm.yml
+++ b/.github/workflows/release-wasm.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   build-wasm-dist:
-    name: "wasm dist (sem + mutex, cortex-m4f)"
+    name: "wasm dist (sem + mutex + msgq, cortex-m4f)"
     runs-on: ubuntu-22.04
     container:
       image: ghcr.io/zephyrproject-rtos/ci-base:v0.29.0

--- a/docs/wasm-module-distribution.md
+++ b/docs/wasm-module-distribution.md
@@ -61,8 +61,20 @@ bench integration):
 
 Scope note: the **give** hot path is the shipped surface today (the silicon-measured
 907-cyc handoff path, re-baseline pending synth#311-fix validation); take/init stay
-native. The same pattern extends per-primitive (`GALE_WASM_LTO_MUTEX` next, gated on
-synth#237/v0.11.37 validation).
+native. The same pattern now extends across three primitives, each shipping its hot
+path with the rest of the object native:
+
+| module | `CONFIG_GALE_WASM_LTO_*` | dissolved surface | native | tramp |
+|--------|-------------------------|-------------------|--------|-------|
+| sem    | `_SEM`   | `z_impl_k_sem_give`   | take/init             | value-path (none) |
+| mutex  | `_MUTEX` | `z_impl_k_mutex_unlock` | lock/init           | `r11=0` (`gale_wasm_mutex_tramp.S`) |
+| msgq   | `_MSGQ`  | `z_impl_k_msgq_put` (wake-reader / put-ok / return-full) | put-pend (`gale_w_msgq_pend`), get/init | `r11=0` (`gale_wasm_msgq_tramp.S`) |
+
+msgq is the first module whose dissolved surface delegates one decided action
+(`PUT_PEND`, the blocking full-queue case) back to a native wrapper — the wait
+queue and scheduling stay native, so only the non-blocking hot path is dissolved.
+Its third argument (`k_timeout_t`, an 8-byte `{ ticks }` struct) crosses the wasm
+seam as an `int64_t` (AAPCS r2:r3-identical).
 
 ## Release flow
 

--- a/scripts/build-wasm-dist.sh
+++ b/scripts/build-wasm-dist.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build the gale wasm-cross-LTO release artifacts (sem + mutex, cortex-m4f lane).
+# Build the gale wasm-cross-LTO release artifacts (sem + mutex + msgq, cortex-m4f lane).
 #
 # Pipeline per docs/wasm-module-distribution.md:
 #   clang(wasm32) shim+FFI -> wasm-ld (DCE, exported entry) -> loom inline
@@ -73,16 +73,35 @@ build_module mutex "$GALE_ROOT/zephyr/wasm/mutex_unlock_shim.c" \
   z_impl_k_mutex_unlock gale_k_mutex_unlock_decide synth_k_mutex_unlock_body \
   "--native-pointer-abi" "${MTX_RENAMES[@]}"
 
+# msgq imports the same spinlock/wake set as mutex (k_spin_lock + k_spin_unlock,
+# unpend, ready, return_value_set, reschedule). gale_w_thread_swap_data /
+# gale_w_memcpy / gale_w_msgq_pend are already gale_w_* symbols (undefined
+# imports resolved at consume link) so they need no rename.
+MSGQ_RENAMES=(
+  k_spin_lock=gale_w_spin_lock
+  k_spin_unlock=gale_w_spin_unlock
+  z_unpend_first_thread=gale_w_unpend_first_thread
+  z_ready_thread=gale_w_ready_thread
+  arch_thread_return_value_set=gale_w_arch_thread_return_value_set
+  z_reschedule=gale_w_reschedule
+)
+
+# 2/3. msgq (pointer-arg path -> --native-pointer-abi + r11=0 trampoline at consume time)
+build_module msgq "$GALE_ROOT/zephyr/wasm/msgq_put_shim.c" \
+  z_impl_k_msgq_put gale_k_msgq_put_decide synth_k_msgq_put_body \
+  "--native-pointer-abi" "${MSGQ_RENAMES[@]}"
+
 # 4. manifest (the trust anchor; sigil signs this)
 cat > "$OUT/gale-wasm-manifest-$VER.json" <<JSON
 {
   "version": "$VER",
-  "primitives": ["sem", "mutex"],
+  "primitives": ["sem", "mutex", "msgq"],
   "surfaces": {
     "sem": "z_impl_k_sem_give (give hot path; take/init native)",
-    "mutex": "z_impl_k_mutex_unlock (unlock hot path; lock/init native; needs r11=0 trampoline)"
+    "mutex": "z_impl_k_mutex_unlock (unlock hot path; lock/init native; needs r11=0 trampoline)",
+    "msgq": "z_impl_k_msgq_put (put hot path: wake-reader / put-ok / return-full dissolved; pend delegates to native gale_w_msgq_pend; get/init native; needs r11=0 trampoline)"
   },
-  "pipeline": "clang -> wasm-ld -> loom optimize --passes inline -> synth --target cortex-m4f [--native-pointer-abi for mutex] --all-exports --relocatable -> objcopy gale_w_* renames",
+  "pipeline": "clang -> wasm-ld -> loom optimize --passes inline -> synth --target cortex-m4f [--native-pointer-abi for mutex+msgq] --all-exports --relocatable -> objcopy gale_w_* renames",
   "tools": {
     "clang": "$($CLANG --version | head -1)",
     "wasm-ld": "$($WASMLD --version | head -1)",
@@ -93,9 +112,11 @@ cat > "$OUT/gale-wasm-manifest-$VER.json" <<JSON
     "gale-wasm-sem-$VER.wasm": "$(sha "$OUT/gale-wasm-sem-$VER.wasm")",
     "gale-wasm-sem-$VER-cortex-m4f.o": "$(sha "$OUT/gale-wasm-sem-$VER-cortex-m4f.o")",
     "gale-wasm-mutex-$VER.wasm": "$(sha "$OUT/gale-wasm-mutex-$VER.wasm")",
-    "gale-wasm-mutex-$VER-cortex-m4f.o": "$(sha "$OUT/gale-wasm-mutex-$VER-cortex-m4f.o")"
+    "gale-wasm-mutex-$VER-cortex-m4f.o": "$(sha "$OUT/gale-wasm-mutex-$VER-cortex-m4f.o")",
+    "gale-wasm-msgq-$VER.wasm": "$(sha "$OUT/gale-wasm-msgq-$VER.wasm")",
+    "gale-wasm-msgq-$VER-cortex-m4f.o": "$(sha "$OUT/gale-wasm-msgq-$VER-cortex-m4f.o")"
   },
-  "consume": "CONFIG_GALE_KERNEL_{SEM,MUTEX}=y CONFIG_GALE_WASM_LTO_{SEM,MUTEX}=y + -DGALE_WASM_LTO_OBJ_DIR=<this dir>; the mutex object links with gale_wasm_mutex_tramp.S (r11=0); verify manifest signature first (sigil)"
+  "consume": "CONFIG_GALE_KERNEL_{SEM,MUTEX,MSGQ}=y CONFIG_GALE_WASM_LTO_{SEM,MUTEX,MSGQ}=y + -DGALE_WASM_LTO_OBJ_DIR=<this dir>; the mutex+msgq objects link with gale_wasm_{mutex,msgq}_tramp.S (r11=0); verify manifest signature first (sigil)"
 }
 JSON
 echo "wasm dist -> $OUT"; ls -la "$OUT"

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -710,6 +710,46 @@ zephyr_library_include_directories(
 zephyr_library_link_libraries(${GALE_FFI_LIB})
 add_dependencies(gale_msgq gale_ffi_build)
 
+# --------------------------------------------------------------------------
+# wasm-cross-LTO msgq variant (CONFIG_GALE_WASM_LTO_MSGQ):
+# link the RELEASED dissolved object (gale-wasm-msgq-<ver>-<target>.o) in
+# place of the native z_impl_k_msgq_put. Artifact discovery:
+#   -DGALE_WASM_LTO_MSGQ_OBJ=<path to the .o>           (explicit), or
+#   -DGALE_WASM_LTO_OBJ_DIR=<release-assets dir>        (matches gale-wasm-msgq-*-cortex-m4f.o)
+# The object's kernel imports are pre-renamed to gale_w_* at release-build
+# time; wasm/gale_wasm_wrappers.c provides those entry points (incl the
+# msgq-only gale_w_msgq_pend / gale_w_thread_swap_data / gale_w_memcpy) and
+# wasm/gale_wasm_msgq_tramp.S provides the r11=0 native-pointer bridge.
+# See docs/wasm-module-distribution.md.
+# --------------------------------------------------------------------------
+if(CONFIG_GALE_WASM_LTO_MSGQ)
+  if(NOT DEFINED GALE_WASM_LTO_MSGQ_OBJ AND DEFINED GALE_WASM_LTO_OBJ_DIR)
+    file(GLOB _gale_wasm_msgq_candidates "${GALE_WASM_LTO_OBJ_DIR}/gale-wasm-msgq-*cortex-m4f.o")
+    list(LENGTH _gale_wasm_msgq_candidates _n)
+    if(_n EQUAL 1)
+      list(GET _gale_wasm_msgq_candidates 0 GALE_WASM_LTO_MSGQ_OBJ)
+    elseif(_n GREATER 1)
+      message(FATAL_ERROR "GALE_WASM_LTO_OBJ_DIR contains ${_n} msgq objects; pass -DGALE_WASM_LTO_MSGQ_OBJ explicitly")
+    endif()
+  endif()
+  if(NOT DEFINED GALE_WASM_LTO_MSGQ_OBJ)
+    message(FATAL_ERROR "CONFIG_GALE_WASM_LTO_MSGQ=y needs -DGALE_WASM_LTO_MSGQ_OBJ=<.o> or -DGALE_WASM_LTO_OBJ_DIR=<dir> (release assets; see docs/wasm-module-distribution.md)")
+  endif()
+  if(NOT EXISTS ${GALE_WASM_LTO_MSGQ_OBJ})
+    message(FATAL_ERROR "wasm msgq object not found: ${GALE_WASM_LTO_MSGQ_OBJ}")
+  endif()
+  message(STATUS "Gale: wasm-cross-LTO msgq put -> ${GALE_WASM_LTO_MSGQ_OBJ}")
+  zephyr_library_compile_definitions(GALE_WASM_LTO_OVERRIDE_MSGQ_PUT=1)
+  zephyr_library_sources(wasm/gale_wasm_msgq_tramp.S)
+  # gale_wasm_wrappers.c defines the shared gale_w_* entry points. Compile it
+  # here only if neither the sem nor the mutex library already did — otherwise
+  # gale_w_* would be multiply-defined at final link.
+  if(NOT CONFIG_GALE_WASM_LTO_SEM AND NOT CONFIG_GALE_WASM_LTO_MUTEX)
+    zephyr_library_sources(wasm/gale_wasm_wrappers.c)
+  endif()
+  zephyr_library_link_libraries(${GALE_WASM_LTO_MSGQ_OBJ})
+endif() # CONFIG_GALE_WASM_LTO_MSGQ
+
 endif() # CONFIG_GALE_KERNEL_MSGQ
 
 # ==========================================================================

--- a/zephyr/Kconfig
+++ b/zephyr/Kconfig
@@ -86,6 +86,24 @@ config GALE_KERNEL_MSGQ
 	  polling, and tracing remain native Zephyr C.
 	  Requires a Rust toolchain for the target architecture.
 
+config GALE_WASM_LTO_MSGQ
+	bool "Link the released wasm-cross-LTO message-queue put path"
+	depends on GALE_KERNEL_MSGQ
+	default n
+	help
+	  Replace the native z_impl_k_msgq_put with the prebuilt
+	  wasm-cross-LTO object shipped with gale releases
+	  (gale-wasm-msgq-<ver>-<target>.o): the verified Rust decision
+	  function seam-dissolved into the C put hot path at the wasm
+	  level (clang -> wasm-ld -> loom inline -> synth), compiled to a
+	  relocatable native object. The dissolved surface is the put hot
+	  path (wake-reader / put-ok / return-full); the blocking pend path
+	  and k_msgq_get / init / cleanup remain native Zephyr C. Point the
+	  build at the artifact via -DGALE_WASM_LTO_OBJ_DIR=<dir of release
+	  assets> or -DGALE_WASM_LTO_MSGQ_OBJ=<path to the .o>. Verify the
+	  release manifest signature (sigil) before consuming the artifacts
+	  in a safety build. See docs/wasm-module-distribution.md.
+
 config GALE_KERNEL_STACK
 	bool "Use Gale formally verified stack"
 	depends on MULTITHREADING

--- a/zephyr/gale_msgq.c
+++ b/zephyr/gale_msgq.c
@@ -171,6 +171,14 @@ int z_msgq_cleanup_sched_locked(struct k_msgq *msgq)
  * Apply:   C executes the decision (memcpy, wake, pend, or return).
  * ----------------------------------------------------------------------- */
 
+/* GALE_WASM_LTO_OVERRIDE_MSGQ_PUT: when defined (CONFIG_GALE_WASM_LTO_MSGQ),
+ * z_impl_k_msgq_put is supplied by the released wasm-cross-LTO object instead
+ * (see wasm/gale_wasm_msgq_tramp.S + docs/wasm-module-distribution.md); the
+ * native implementation below is compiled out. Same-TU callers (e.g.
+ * z_impl_k_msgq_put_front's full-queue fallthrough) bind to the external
+ * symbol at link time.
+ */
+#ifndef GALE_WASM_LTO_OVERRIDE_MSGQ_PUT
 int z_impl_k_msgq_put(struct k_msgq *msgq, const void *data,
 		       k_timeout_t timeout)
 {
@@ -234,6 +242,7 @@ int z_impl_k_msgq_put(struct k_msgq *msgq, const void *data,
 
 	return 0;
 }
+#endif /* GALE_WASM_LTO_OVERRIDE_MSGQ_PUT */
 
 /* -----------------------------------------------------------------------
  * z_impl_k_msgq_put_front  (uses Phase 1 gale_msgq_put_front)

--- a/zephyr/wasm/gale_wasm_msgq_tramp.S
+++ b/zephyr/wasm/gale_wasm_msgq_tramp.S
@@ -1,0 +1,22 @@
+/* wasm-cross-LTO trampoline for the dissolved z_impl_k_msgq_put.
+ *
+ * The shipped object's body (synth_k_msgq_put_body) addresses its k_msgq *
+ * argument's fields via the wasm linear-memory base register r11: [r11 + ptr].
+ * With r11 = 0 that is a native dereference, so this thin AAPCS-compatible
+ * wrapper zeroes r11 around the call (the --native-pointer-abi convention).
+ * Arguments pass straight through: r0 = msgq*, r1 = data*, r2:r3 = the 8-byte
+ * k_timeout_t (== int64_t ticks; the shim's third parameter). Validated on
+ * NUCLEO-G474RE silicon: k_msgq_put = 673 cyc, SELFCHECK rc=0 val=0xABCD on
+ * synth 0.11.48 (post synth#359 .bss-sizing fix). See gale-smart-data
+ * NOTES-wasm-cross-lto-spike.md + msgq-microbench/.
+ */
+	.syntax unified
+	.thumb
+	.section .text.gale_wasm_msgq_tramp,"ax",%progbits
+	.global z_impl_k_msgq_put
+	.thumb_func
+z_impl_k_msgq_put:
+	push	{r11, lr}
+	mov.w	r11, #0
+	bl	synth_k_msgq_put_body
+	pop	{r11, pc}

--- a/zephyr/wasm/gale_wasm_wrappers.c
+++ b/zephyr/wasm/gale_wasm_wrappers.c
@@ -16,6 +16,7 @@
  */
 #include <zephyr/kernel.h>
 #include <zephyr/kernel_structs.h>
+#include <string.h>
 #include <wait_q.h>
 #include <ksched.h>
 
@@ -85,4 +86,38 @@ int gale_w_adjust_thread_prio(struct k_thread *thread, int new_prio)
 int gale_w_thread_prio(struct k_thread *thread)
 {
 	return thread->base.prio;
+}
+
+/* msgq put shim (msgq_put_shim.c) wrappers. k_thread is opaque in the shim and
+ * k_msgq_put can copy arbitrary-size messages and block, none of which the
+ * dissolved object can do against an opaque thread / without Zephyr headers:
+ *   - gale_w_thread_swap_data: read base.swap_data — the waiting reader's
+ *     destination buffer (set by k_msgq_get before it pended); the put copies
+ *     the message into it on WAKE_READER.
+ *   - gale_w_memcpy: out-of-line memcpy (the wasm shim has no libc; this keeps
+ *     the byte copy a clean native call rather than a wasm bulk-memory op).
+ *   - gale_w_msgq_pend: the PUT_PEND blocking path. wait_q / scheduling stay
+ *     native (docs/wasm-module-distribution.md). The shim passes &msgq (==
+ *     &msgq->wait_q, first member) and the 8-byte timeout as int64 ticks; we
+ *     stash the message pointer in swap_data and z_pend_curr on gale_wasm_lock
+ *     — the same lock the shim's spin ops use, so the put-pend / get-wake
+ *     handshake shares one critical section (valid for the !SMP 0-byte-spinlock
+ *     config these modules target). */
+void *gale_w_thread_swap_data(struct k_thread *thread)
+{
+	return thread->base.swap_data;
+}
+
+void gale_w_memcpy(void *dst, const void *src, uint32_t n)
+{
+	(void)memcpy(dst, src, (size_t)n);
+}
+
+int gale_w_msgq_pend(void *wait_q, k_spinlock_key_t key,
+		     const void *data, int64_t timeout_ticks)
+{
+	k_timeout_t timeout = { .ticks = (k_ticks_t)timeout_ticks };
+
+	_current->base.swap_data = (void *)data;
+	return z_pend_curr(&gale_wasm_lock, key, (_wait_q_t *)wait_q, timeout);
 }

--- a/zephyr/wasm/msgq_put_shim.c
+++ b/zephyr/wasm/msgq_put_shim.c
@@ -1,0 +1,128 @@
+/*
+ * Minimal wasm-side host of z_impl_k_msgq_put — the message-queue analogue of
+ * sem_give_shim.c / mutex_unlock_shim.c. Replicates gale_msgq.c's put hot path
+ * with the Zephyr kernel APIs as externs (which become wasm imports), so the
+ * shim itself compiles to wasm32-unknown-unknown without pulling in Zephyr
+ * headers. This puts the C <-> Rust seam (gale_k_msgq_put_decide) INSIDE the
+ * wasm bundle: wasm-ld merges it with gale-ffi.wasm, loom inlines through it,
+ * synth produces ARM with the seam dissolved (no `bl gale_k_msgq_put_decide`).
+ *
+ * Surface: z_impl_k_msgq_put (put hot path). k_msgq_get / init / cleanup stay
+ * native (gale_msgq.c). All four decided actions are handled faithfully:
+ *   WAKE_READER  — copy bytes into the waiting reader's buffer + wake
+ *   PUT_OK       — copy bytes into the ring buffer at the write slot
+ *   RETURN_FULL  — non-blocking full: return d.ret (-ENOMSG)
+ *   PUT_PEND     — blocking full: delegate to gale_w_msgq_pend (native
+ *                  z_pend_curr; the wait queue / scheduling stay native C,
+ *                  exactly as docs/wasm-module-distribution.md prescribes).
+ *
+ * SHIM DISCIPLINE (default config: !SMP / !SPIN_VALIDATE / !NONZERO_SPINLOCK):
+ * struct k_spinlock is a ZERO-size empty struct, so we OMIT the embedded `lock`
+ * field (modelling it as sized would shift every later field and corrupt the
+ * struct on store) and use a file-scope static spinlock. In this config every
+ * k_spin_lock degenerates to arch_irq_lock(), so the shim's static lock and
+ * gale_msgq.c's per-object lock are the SAME critical section — which is what
+ * makes the pend(here)/wake(native get) handshake on msgq->wait_q safe across
+ * the wasm-put / native-get boundary. Same constraint the sem/mutex modules
+ * assume; not valid for SMP builds (those keep the native z_impl_k_msgq_put).
+ *
+ * ABI: the third argument k_timeout_t is a struct { k_ticks_t ticks } (one
+ * 8-byte member), passed in r2:r3 under AAPCS — identical to a bare int64_t.
+ * The shim therefore takes int64_t timeout_ticks (K_NO_WAIT.ticks == 0,
+ * K_FOREVER.ticks == -1) and reconstructs k_timeout_t inside gale_w_msgq_pend.
+ *
+ * Faithful Zephyr v4.4.0 struct k_msgq field offsets (0-byte spinlock omitted,
+ * WAITQ_DUMB): wait_q@0(8) | msg_size@8 | max_msgs@12 | buffer_start@16 |
+ * buffer_end@20 | read_ptr@24 | write_ptr@28 | used_msgs@32. (Z_DECL_POLL_EVENT
+ * / flags come AFTER used_msgs, so CONFIG_POLL doesn't affect any touched field;
+ * poll-event handling on PUT_OK stays native — not exercised by this surface.)
+ */
+
+#include <stdint.h>
+
+/* Opaque k_thread — never deref'd in the shim; the kernel owns its layout. */
+struct k_thread;
+struct k_spinlock { uint8_t lock_internal; };   /* type only; never embedded (0-byte real) */
+typedef struct { uint32_t key; } k_spinlock_key_t;
+
+struct k_msgq {
+	void     *wq_head;       /* @0  _wait_q_t wait_q (head,tail) */
+	void     *wq_tail;       /* @4  */
+	uint32_t  msg_size;      /* @8  (size_t on 32-bit) — 0-byte k_spinlock omitted */
+	uint32_t  max_msgs;      /* @12 */
+	char     *buffer_start;  /* @16 */
+	char     *buffer_end;    /* @20 */
+	char     *read_ptr;      /* @24 */
+	char     *write_ptr;     /* @28 */
+	uint32_t  used_msgs;     /* @32 */
+};
+static struct k_spinlock msgq_lock;
+
+/* Kernel API externs -> wasm imports -> native `bl` after synth-emit (renamed
+ * to the gale_w_* wrappers by build-wasm-dist.sh's objcopy pass). */
+extern k_spinlock_key_t  k_spin_lock(struct k_spinlock *);
+extern void              k_spin_unlock(struct k_spinlock *, k_spinlock_key_t);
+extern struct k_thread * z_unpend_first_thread(void *wait_q);
+extern void              z_ready_thread(struct k_thread *);
+extern void              arch_thread_return_value_set(struct k_thread *, uint32_t);
+extern int               z_reschedule(struct k_spinlock *, k_spinlock_key_t);
+/* k_thread is opaque here: these out-of-line wrappers do what the native
+ * z_impl_k_msgq_put reaches via struct fields / static helpers. */
+extern void *            gale_w_thread_swap_data(struct k_thread *);     /* reader's dest buffer */
+extern void              gale_w_memcpy(void *dst, const void *src, uint32_t n);
+extern int               gale_w_msgq_pend(void *wait_q, k_spinlock_key_t key,
+					  const void *data, int64_t timeout_ticks);
+
+/* #[repr(C)] GaleMsgqPutDecision — 16 bytes, returned by value (sret). */
+struct gale_msgq_put_decision { int32_t ret; uint8_t action; uint32_t new_write_idx; uint32_t new_used; };
+extern struct gale_msgq_put_decision gale_k_msgq_put_decide(
+	uint32_t write_idx, uint32_t used_msgs, uint32_t max_msgs,
+	uint32_t has_waiter, uint32_t is_no_wait);
+
+#define GALE_MSGQ_ACTION_PUT_OK      0
+#define GALE_MSGQ_ACTION_WAKE_READER 1
+#define GALE_MSGQ_ACTION_PUT_PEND    2
+#define GALE_MSGQ_ACTION_RETURN_FULL 3
+
+int z_impl_k_msgq_put(struct k_msgq *msgq, const void *data, int64_t timeout_ticks)
+{
+	uint32_t is_no_wait = (timeout_ticks == 0) ? 1U : 0U;   /* K_NO_WAIT.ticks == 0 */
+
+	k_spinlock_key_t key = k_spin_lock(&msgq_lock);
+
+	/* Extract: try to unpend first waiter (side effect: removes from queue).
+	 * wait_q is k_msgq's first member, so &msgq == &msgq->wait_q. */
+	struct k_thread *reader = z_unpend_first_thread((void *)msgq);
+
+	uint32_t write_idx = (uint32_t)(msgq->write_ptr - msgq->buffer_start) / msgq->msg_size;
+
+	struct gale_msgq_put_decision d = gale_k_msgq_put_decide(
+		write_idx, msgq->used_msgs, msgq->max_msgs,
+		reader != (struct k_thread *)0 ? 1U : 0U, is_no_wait);
+
+	switch (d.action) {
+	case GALE_MSGQ_ACTION_WAKE_READER:
+		/* Receiver was waiting — copy the message into its buffer
+		 * (reader stashed its dest in swap_data before pending in get). */
+		gale_w_memcpy(gale_w_thread_swap_data(reader), data, msgq->msg_size);
+		arch_thread_return_value_set(reader, 0U);
+		z_ready_thread(reader);
+		z_reschedule(&msgq_lock, key);
+		return d.ret;
+	case GALE_MSGQ_ACTION_PUT_OK:
+		/* Space available — store at the write slot, advance ring. */
+		gale_w_memcpy(msgq->write_ptr, data, msgq->msg_size);
+		msgq->write_ptr = msgq->buffer_start + (uint64_t)d.new_write_idx * msgq->msg_size;
+		msgq->used_msgs = d.new_used;
+		k_spin_unlock(&msgq_lock, key);
+		return d.ret;
+	case GALE_MSGQ_ACTION_PUT_PEND:
+		/* Queue full, blocking — pend current thread natively. The
+		 * unpend above found no reader, so the wait_q is untouched. */
+		return gale_w_msgq_pend((void *)msgq, key, data, timeout_ticks);
+	case GALE_MSGQ_ACTION_RETURN_FULL:
+	default:
+		k_spin_unlock(&msgq_lock, key);
+		return d.ret;   /* -ENOMSG */
+	}
+}


### PR DESCRIPTION
## Summary

Promotes the silicon-validated **`k_msgq_put`** to a shippable wasm-cross-LTO module — the **3rd primitive** after sem (#59) and mutex (#60) — now that **synth v0.11.48** ships both of msgq's blockers:
- **#372** — arm `i64.load`/`i64.store` full lowering (v0.11.47)
- **#359** — native-pointer `.bss` sizing (v0.11.48, silicon-confirmed)

This extends the wasm-dist primitive set toward a feature release, mirroring the #60 mutex structure exactly.

## What's here

**Build** (`scripts/build-wasm-dist.sh`):
- `zephyr/wasm/msgq_put_shim.c` — production shim. Faithful Zephyr v4.4.0 `k_msgq` layout (0-byte spinlock omitted, `WAITQ_DUMB`); the seam (`gale_k_msgq_put_decide`) lives inside the bundle. All four decided actions handled: **WAKE_READER / PUT_OK / RETURN_FULL dissolved**; **PUT_PEND** (blocking full-queue) delegates to native `gale_w_msgq_pend` so the wait queue + scheduling stay native C.
- `zephyr/wasm/gale_wasm_msgq_tramp.S` — `r11=0` trampoline (`--native-pointer-abi`).
- `zephyr/wasm/gale_wasm_wrappers.c` — `+gale_w_msgq_pend` (native `z_pend_curr`), `gale_w_thread_swap_data`, `gale_w_memcpy`.

**Consume:**
- `zephyr/gale_msgq.c` — `#ifndef GALE_WASM_LTO_OVERRIDE_MSGQ_PUT` guard (mirrors `gale_mutex.c`).
- `zephyr/Kconfig` — `CONFIG_GALE_WASM_LTO_MSGQ`.
- `zephyr/CMakeLists.txt` — consume block; `gale_wasm_wrappers.c` compiled once across sem/mutex/msgq.
- `release-wasm.yml` + `docs/wasm-module-distribution.md` (now a 3-row module table).

## First module with a delegated action + non-trivial ABI

msgq is the first whose dissolved surface hands one decided action (`PUT_PEND`) back to native, and the first with a non-pointer 3rd arg: `k_timeout_t` (8-byte `{ ticks }`) crosses the seam as `int64_t` (AAPCS r2:r3-identical).

## Oracles run

| Gate | Result |
|------|--------|
| build pipeline (synth 0.11.48 + loom 1.1.14) | ✅ ET_REL `.o`; `synth_k_msgq_put_body` global, `gale_k_msgq_put_decide` internalized (local), all **9** kernel imports renamed to `gale_w_*`, zero un-renamed leakage |
| seam state | same internalized-seam as shipped mutex module (full inline-dissolution pending loom#219) |
| `rivet validate` | ✅ PASS (exit 0) |
| cargo workspace | untouched (diff is `zephyr/` + `scripts/` only; 1953 tests unaffected) |

## Kill-criterion / remaining gate

On-silicon validation of **this production shim** — esp. the `k_timeout_t`→`int64` ABI, general-`msg_size` `memcpy`, and the `PUT_PEND` path — before production-declaring. The **no-wait hot path is already silicon-GREEN at 673 cyc** (G474RE, synth 0.11.48) via the microbench POC shim; this PR generalizes that shim to all four actions.

Follow-up (separate, in `gale-smart-data`): add a `build_primitive msgq_put` lane to the wasm-testbed `primitives_codegen_check.sh` for per-release regression coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)