### PR TITLE
fix(ci): relocate zephyr-tests west workspace to /mnt — fix intermittent ENOSPC

### DIFF
--- a/.github/workflows/llvm-lto.yml
+++ b/.github/workflows/llvm-lto.yml
@@ -31,6 +31,11 @@ defaults:
 env:
   HOME: /root
   DOCKER_CONFIG: /tmp/.docker
+  # Authenticate `west sdk install`'s GitHub API release-list fetch (anonymous
+  # 60 req/hr -> 5000/hr) so concurrent jobs don't 403 and fail to install the
+  # SDK. Same root cause fixed in zephyr-tests.yml. Workflow-level -> all jobs.
+  # github.token (the secrets context is not available at workflow-level env).
+  GITHUB_TOKEN: ${{ github.token }}
 
 jobs:
   llvm-lto-build:

--- a/.github/workflows/llvm-lto.yml
+++ b/.github/workflows/llvm-lto.yml
@@ -38,7 +38,11 @@ jobs:
     runs-on: ubuntu-22.04
     container:
       image: ghcr.io/zephyrproject-rtos/ci:v0.29.0
-      options: --user root
+      # Mount the runner's large ephemeral scratch disk (/mnt, ~70 GB). These jobs
+      # run multiple west builds on the full `ci` image — more disk than a
+      # single-build job — so the west workspace + build dirs go on /mnt to avoid
+      # ENOSPC on the ~14 GB root fs (same fix as zephyr-tests.yml).
+      options: --user root --volume /mnt:/mnt
     env:
       HOME: /root
       DOCKER_CONFIG: /tmp/.docker
@@ -74,8 +78,8 @@ jobs:
       - name: Initialize west workspace
         run: |
           pip3 install west
-          west init -m https://github.com/pulseengine/zephyr.git --mr gale/sem-replacement zephyr-workspace
-          cd zephyr-workspace
+          west init -m https://github.com/pulseengine/zephyr.git --mr gale/sem-replacement /mnt/zephyr-workspace
+          cd /mnt/zephyr-workspace
           west update --narrow -o=--depth=1
           for attempt in 1 2 3; do west sdk install -t arm-zephyr-eabi && break || sleep 5; done
 
@@ -116,8 +120,8 @@ jobs:
       - name: "Build baseline (GCC, no Gale)"
         run: |
           . /root/.cargo/env
-          export ZEPHYR_BASE="${GITHUB_WORKSPACE}/zephyr-workspace/zephyr"
-          cd zephyr-workspace
+          export ZEPHYR_BASE="/mnt/zephyr-workspace/zephyr"
+          cd /mnt/zephyr-workspace
           west build -b qemu_cortex_m3 \
             -s zephyr/tests/kernel/semaphore/semaphore \
             -d build-gcc-baseline
@@ -127,9 +131,9 @@ jobs:
       - name: "Build GCC + Gale"
         run: |
           . /root/.cargo/env
-          export ZEPHYR_BASE="${GITHUB_WORKSPACE}/zephyr-workspace/zephyr"
+          export ZEPHYR_BASE="/mnt/zephyr-workspace/zephyr"
           export GALE_ROOT="${GITHUB_WORKSPACE}/gale"
-          cd zephyr-workspace
+          cd /mnt/zephyr-workspace
           west build -b qemu_cortex_m3 \
             -s zephyr/tests/kernel/semaphore/semaphore \
             -d build-gcc-gale \
@@ -154,9 +158,9 @@ jobs:
       - name: "Build LLVM + Gale (no LTO)"
         run: |
           . /root/.cargo/env
-          export ZEPHYR_BASE="${GITHUB_WORKSPACE}/zephyr-workspace/zephyr"
+          export ZEPHYR_BASE="/mnt/zephyr-workspace/zephyr"
           export GALE_ROOT="${GITHUB_WORKSPACE}/gale"
-          cd zephyr-workspace
+          cd /mnt/zephyr-workspace
           west build -b qemu_cortex_m3 \
             -s zephyr/tests/kernel/semaphore/semaphore \
             -d build-llvm-gale \
@@ -180,9 +184,9 @@ jobs:
       - name: "Build LLVM + Gale + LTO"
         run: |
           . /root/.cargo/env
-          export ZEPHYR_BASE="${GITHUB_WORKSPACE}/zephyr-workspace/zephyr"
+          export ZEPHYR_BASE="/mnt/zephyr-workspace/zephyr"
           export GALE_ROOT="${GITHUB_WORKSPACE}/gale"
-          cd zephyr-workspace
+          cd /mnt/zephyr-workspace
           west build -b qemu_cortex_m3 \
             -s zephyr/tests/kernel/semaphore/semaphore \
             -d build-llvm-lto \
@@ -201,7 +205,7 @@ jobs:
       - name: "Run semaphore tests (LLVM+LTO)"
         run: |
           . /root/.cargo/env
-          export ZEPHYR_BASE="${GITHUB_WORKSPACE}/zephyr-workspace/zephyr"
+          export ZEPHYR_BASE="/mnt/zephyr-workspace/zephyr"
           # QEMU may not be found by LLVM toolchain variant. Use SDK QEMU directly.
           # SDK 1.0.x: hosttools/sysroots/... (Poky hosttools layout).
           # SDK 0.x:   sysroots/... (flat layout).
@@ -214,7 +218,7 @@ jobs:
             QEMU=$(which qemu-system-arm 2>/dev/null || echo "")
           fi
           if [ -n "${QEMU}" ]; then
-            cd zephyr-workspace
+            cd /mnt/zephyr-workspace
             timeout 120 "${QEMU}" -cpu cortex-m3 -machine lm3s6965evb -nographic \
               -vga none -net none -icount shift=6,align=off,sleep=off \
               -rtc clock=vm -kernel build-llvm-lto/zephyr/zephyr.elf 2>&1 | tee test-llvm-lto.log &
@@ -233,7 +237,7 @@ jobs:
       - name: "Check inlining + compare sizes"
         if: always()
         run: |
-          cd zephyr-workspace
+          cd /mnt/zephyr-workspace
           echo "=== Symbol check ==="
           # Count + list gale_ FFI symbols that survived the link. The goal
           # of cross-language LTO is for these to be inlined into the C
@@ -296,7 +300,11 @@ jobs:
     runs-on: ubuntu-22.04
     container:
       image: ghcr.io/zephyrproject-rtos/ci:v0.29.0
-      options: --user root
+      # Mount the runner's large ephemeral scratch disk (/mnt, ~70 GB). These jobs
+      # run multiple west builds on the full `ci` image — more disk than a
+      # single-build job — so the west workspace + build dirs go on /mnt to avoid
+      # ENOSPC on the ~14 GB root fs (same fix as zephyr-tests.yml).
+      options: --user root --volume /mnt:/mnt
     strategy:
       fail-fast: false
       matrix:
@@ -348,8 +356,8 @@ jobs:
       - name: Initialize west workspace
         run: |
           pip3 install west
-          west init -m https://github.com/pulseengine/zephyr.git --mr gale/sem-replacement zephyr-workspace
-          cd zephyr-workspace
+          west init -m https://github.com/pulseengine/zephyr.git --mr gale/sem-replacement /mnt/zephyr-workspace
+          cd /mnt/zephyr-workspace
           west update --narrow -o=--depth=1
           for attempt in 1 2 3; do west sdk install -t arm-zephyr-eabi && break || sleep 5; done
 
@@ -384,9 +392,9 @@ jobs:
       - name: Build and run test (LLVM+LTO)
         run: |
           . /root/.cargo/env
-          export ZEPHYR_BASE="${GITHUB_WORKSPACE}/zephyr-workspace/zephyr"
+          export ZEPHYR_BASE="/mnt/zephyr-workspace/zephyr"
           export GALE_ROOT="${GITHUB_WORKSPACE}/gale"
-          cd zephyr-workspace
+          cd /mnt/zephyr-workspace
           west build -b qemu_cortex_m3 \
             -s "zephyr/${TEST_PATH}" \
             -- \

--- a/.github/workflows/llvm-lto.yml
+++ b/.github/workflows/llvm-lto.yml
@@ -86,7 +86,7 @@ jobs:
           west init -m https://github.com/pulseengine/zephyr.git --mr gale/sem-replacement /mnt/zephyr-workspace
           cd /mnt/zephyr-workspace
           west update --narrow -o=--depth=1
-          for attempt in 1 2 3; do west sdk install -t arm-zephyr-eabi && break || sleep 5; done
+          for attempt in 1 2 3; do west sdk install -t arm-zephyr-eabi --personal-access-token "${GITHUB_TOKEN}" && break || sleep 5; done
 
       - name: Setup SDK paths
         run: |
@@ -364,7 +364,7 @@ jobs:
           west init -m https://github.com/pulseengine/zephyr.git --mr gale/sem-replacement /mnt/zephyr-workspace
           cd /mnt/zephyr-workspace
           west update --narrow -o=--depth=1
-          for attempt in 1 2 3; do west sdk install -t arm-zephyr-eabi && break || sleep 5; done
+          for attempt in 1 2 3; do west sdk install -t arm-zephyr-eabi --personal-access-token "${GITHUB_TOKEN}" && break || sleep 5; done
 
       - name: Setup SDK paths
         run: |

--- a/.github/workflows/zephyr-tests.yml
+++ b/.github/workflows/zephyr-tests.yml
@@ -31,7 +31,13 @@ jobs:
     runs-on: ubuntu-22.04
     container:
       image: ghcr.io/zephyrproject-rtos/ci-base:v0.29.0
-      options: --user root
+      # Mount the runner's large ephemeral scratch disk (/mnt, ~70 GB) into the
+      # container. The ci-base image layers (full multi-arch Zephyr SDK) already
+      # consume most of the host root fs (~14 GB free); putting the west
+      # workspace + build artifacts on / tips unlucky jobs into ENOSPC (the
+      # runner itself crashes writing its diag log). The west workspace below is
+      # created under /mnt so the heavy writes land on the big disk instead.
+      options: --user root --volume /mnt:/mnt
     strategy:
       fail-fast: false
       matrix:
@@ -152,8 +158,8 @@ jobs:
       - name: Initialize west workspace
         run: |
           pip3 install west
-          west init -m https://github.com/pulseengine/zephyr.git --mr gale/sem-replacement zephyr-workspace
-          cd zephyr-workspace
+          west init -m https://github.com/pulseengine/zephyr.git --mr gale/sem-replacement /mnt/zephyr-workspace
+          cd /mnt/zephyr-workspace
           west update --narrow -o=--depth=1
           for attempt in 1 2 3; do west sdk install -t arm-zephyr-eabi && break || sleep 5; done
 
@@ -162,9 +168,9 @@ jobs:
           TEST_PATH: ${{ matrix.test_path }}
         run: |
           . /root/.cargo/env
-          export ZEPHYR_BASE="${GITHUB_WORKSPACE}/zephyr-workspace/zephyr"
+          export ZEPHYR_BASE="/mnt/zephyr-workspace/zephyr"
           export GALE_ROOT="${GITHUB_WORKSPACE}/gale"
-          cd zephyr-workspace
+          cd /mnt/zephyr-workspace
           west build -b qemu_cortex_m3 \
             -s "zephyr/${TEST_PATH}" \
             -- \
@@ -188,7 +194,13 @@ jobs:
     runs-on: ubuntu-22.04
     container:
       image: ghcr.io/zephyrproject-rtos/ci-base:v0.29.0
-      options: --user root
+      # Mount the runner's large ephemeral scratch disk (/mnt, ~70 GB) into the
+      # container. The ci-base image layers (full multi-arch Zephyr SDK) already
+      # consume most of the host root fs (~14 GB free); putting the west
+      # workspace + build artifacts on / tips unlucky jobs into ENOSPC (the
+      # runner itself crashes writing its diag log). The west workspace below is
+      # created under /mnt so the heavy writes land on the big disk instead.
+      options: --user root --volume /mnt:/mnt
     strategy:
       fail-fast: false
       matrix:
@@ -226,8 +238,8 @@ jobs:
       - name: Initialize west workspace
         run: |
           pip3 install west
-          west init -m https://github.com/pulseengine/zephyr.git --mr gale/sem-replacement zephyr-workspace
-          cd zephyr-workspace
+          west init -m https://github.com/pulseengine/zephyr.git --mr gale/sem-replacement /mnt/zephyr-workspace
+          cd /mnt/zephyr-workspace
           west update --narrow -o=--depth=1
           for attempt in 1 2 3; do west sdk install -t arm-zephyr-eabi && break || sleep 5; done
 
@@ -236,9 +248,9 @@ jobs:
           TEST_PATH: ${{ matrix.test_path }}
         run: |
           . /root/.cargo/env
-          export ZEPHYR_BASE="${GITHUB_WORKSPACE}/zephyr-workspace/zephyr"
+          export ZEPHYR_BASE="/mnt/zephyr-workspace/zephyr"
           export GALE_ROOT="${GITHUB_WORKSPACE}/gale"
-          cd zephyr-workspace
+          cd /mnt/zephyr-workspace
           west build -b mps2/an385 \
             -s "zephyr/${TEST_PATH}" \
             -- \
@@ -277,7 +289,13 @@ jobs:
     runs-on: ubuntu-22.04
     container:
       image: ghcr.io/zephyrproject-rtos/ci-base:v0.29.0
-      options: --user root
+      # Mount the runner's large ephemeral scratch disk (/mnt, ~70 GB) into the
+      # container. The ci-base image layers (full multi-arch Zephyr SDK) already
+      # consume most of the host root fs (~14 GB free); putting the west
+      # workspace + build artifacts on / tips unlucky jobs into ENOSPC (the
+      # runner itself crashes writing its diag log). The west workspace below is
+      # created under /mnt so the heavy writes land on the big disk instead.
+      options: --user root --volume /mnt:/mnt
     strategy:
       fail-fast: false
       matrix:
@@ -320,8 +338,8 @@ jobs:
       - name: Initialize west workspace
         run: |
           pip3 install west
-          west init -m https://github.com/pulseengine/zephyr.git --mr gale/sem-replacement zephyr-workspace
-          cd zephyr-workspace
+          west init -m https://github.com/pulseengine/zephyr.git --mr gale/sem-replacement /mnt/zephyr-workspace
+          cd /mnt/zephyr-workspace
           west update --narrow -o=--depth=1
           for attempt in 1 2 3; do west sdk install -t x86_64-zephyr-elf && break || sleep 5; done
 
@@ -330,9 +348,9 @@ jobs:
           TEST_PATH: ${{ matrix.test_path }}
         run: |
           . /root/.cargo/env
-          export ZEPHYR_BASE="${GITHUB_WORKSPACE}/zephyr-workspace/zephyr"
+          export ZEPHYR_BASE="/mnt/zephyr-workspace/zephyr"
           export GALE_ROOT="${GITHUB_WORKSPACE}/gale"
-          cd zephyr-workspace
+          cd /mnt/zephyr-workspace
           west build -b qemu_x86_64 \
             -s "zephyr/${TEST_PATH}" \
             -- \
@@ -354,7 +372,13 @@ jobs:
     runs-on: ubuntu-22.04
     container:
       image: ghcr.io/zephyrproject-rtos/ci-base:v0.29.0
-      options: --user root
+      # Mount the runner's large ephemeral scratch disk (/mnt, ~70 GB) into the
+      # container. The ci-base image layers (full multi-arch Zephyr SDK) already
+      # consume most of the host root fs (~14 GB free); putting the west
+      # workspace + build artifacts on / tips unlucky jobs into ENOSPC (the
+      # runner itself crashes writing its diag log). The west workspace below is
+      # created under /mnt so the heavy writes land on the big disk instead.
+      options: --user root --volume /mnt:/mnt
     env:
       HOME: /root
       DOCKER_CONFIG: /tmp/.docker
@@ -375,8 +399,8 @@ jobs:
       - name: Initialize west workspace
         run: |
           pip3 install west
-          west init -m https://github.com/pulseengine/zephyr.git --mr gale/sem-replacement zephyr-workspace
-          cd zephyr-workspace
+          west init -m https://github.com/pulseengine/zephyr.git --mr gale/sem-replacement /mnt/zephyr-workspace
+          cd /mnt/zephyr-workspace
           west update --narrow -o=--depth=1
           for attempt in 1 2 3; do west sdk install -t arm-zephyr-eabi && break || sleep 5; done
 
@@ -395,8 +419,8 @@ jobs:
       - name: Build baseline (stock Zephyr)
         run: |
           . /root/.cargo/env
-          export ZEPHYR_BASE="${GITHUB_WORKSPACE}/zephyr-workspace/zephyr"
-          cd zephyr-workspace
+          export ZEPHYR_BASE="/mnt/zephyr-workspace/zephyr"
+          cd /mnt/zephyr-workspace
           west build -b qemu_cortex_m3 \
             -s zephyr/tests/kernel/semaphore/semaphore \
             -d build-baseline
@@ -405,9 +429,9 @@ jobs:
       - name: Build with Gale
         run: |
           . /root/.cargo/env
-          export ZEPHYR_BASE="${GITHUB_WORKSPACE}/zephyr-workspace/zephyr"
+          export ZEPHYR_BASE="/mnt/zephyr-workspace/zephyr"
           export GALE_ROOT="${GITHUB_WORKSPACE}/gale"
-          cd zephyr-workspace
+          cd /mnt/zephyr-workspace
           west build -b qemu_cortex_m3 \
             -s zephyr/tests/kernel/semaphore/semaphore \
             -d build-gale \
@@ -421,21 +445,21 @@ jobs:
           echo "=== Binary Size Comparison ==="
           echo ""
           echo "--- Baseline (stock Zephyr) ---"
-          cat zephyr-workspace/baseline-size.txt
+          cat /mnt/zephyr-workspace/baseline-size.txt
           echo ""
           echo "--- With Gale ---"
-          cat zephyr-workspace/gale-size.txt
+          cat /mnt/zephyr-workspace/gale-size.txt
           echo ""
 
-          BASELINE_TEXT=$(tail -1 zephyr-workspace/baseline-size.txt | awk '{print $1}')
-          BASELINE_DATA=$(tail -1 zephyr-workspace/baseline-size.txt | awk '{print $2}')
-          BASELINE_BSS=$(tail -1 zephyr-workspace/baseline-size.txt | awk '{print $3}')
-          BASELINE_TOTAL=$(tail -1 zephyr-workspace/baseline-size.txt | awk '{print $4}')
+          BASELINE_TEXT=$(tail -1 /mnt/zephyr-workspace/baseline-size.txt | awk '{print $1}')
+          BASELINE_DATA=$(tail -1 /mnt/zephyr-workspace/baseline-size.txt | awk '{print $2}')
+          BASELINE_BSS=$(tail -1 /mnt/zephyr-workspace/baseline-size.txt | awk '{print $3}')
+          BASELINE_TOTAL=$(tail -1 /mnt/zephyr-workspace/baseline-size.txt | awk '{print $4}')
 
-          GALE_TEXT=$(tail -1 zephyr-workspace/gale-size.txt | awk '{print $1}')
-          GALE_DATA=$(tail -1 zephyr-workspace/gale-size.txt | awk '{print $2}')
-          GALE_BSS=$(tail -1 zephyr-workspace/gale-size.txt | awk '{print $3}')
-          GALE_TOTAL=$(tail -1 zephyr-workspace/gale-size.txt | awk '{print $4}')
+          GALE_TEXT=$(tail -1 /mnt/zephyr-workspace/gale-size.txt | awk '{print $1}')
+          GALE_DATA=$(tail -1 /mnt/zephyr-workspace/gale-size.txt | awk '{print $2}')
+          GALE_BSS=$(tail -1 /mnt/zephyr-workspace/gale-size.txt | awk '{print $3}')
+          GALE_TOTAL=$(tail -1 /mnt/zephyr-workspace/gale-size.txt | awk '{print $4}')
 
           DELTA_TEXT=$((GALE_TEXT - BASELINE_TEXT))
           DELTA_DATA=$((GALE_DATA - BASELINE_DATA))
@@ -467,7 +491,7 @@ jobs:
             printf "gale_overhead_total %d ns/iter (+/- 0)\n" "$DELTA_TOTAL"
             printf "gale_flash_bytes %d ns/iter (+/- 0)\n" "$GALE_TOTAL"
             printf "baseline_flash_bytes %d ns/iter (+/- 0)\n" "$BASELINE_TOTAL"
-          } > zephyr-workspace/benchmark-output.txt
+          } > /mnt/zephyr-workspace/benchmark-output.txt
 
           # Fail if total overhead exceeds 10% (SYSREQ-PERF-001)
           PERCENT=$((DELTA_TOTAL * 100 / BASELINE_TOTAL))
@@ -484,7 +508,7 @@ jobs:
         with:
           name: Binary Size (semaphore test, qemu_cortex_m3)
           tool: cargo
-          output-file-path: zephyr-workspace/benchmark-output.txt
+          output-file-path: /mnt/zephyr-workspace/benchmark-output.txt
           github-token: ${{ secrets.GITHUB_TOKEN }}
           auto-push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
           comment-on-alert: true

--- a/.github/workflows/zephyr-tests.yml
+++ b/.github/workflows/zephyr-tests.yml
@@ -24,13 +24,14 @@ concurrency:
 env:
   HOME: /root
   DOCKER_CONFIG: /tmp/.docker
-  # Authenticate `west sdk install`'s GitHub API release-list fetch. Without a
-  # token the fetch is anonymous (60 req/hr per runner IP); with ~59 concurrent
-  # jobs all calling it, the limit is blown and jobs fail with
-  #   "Failed to fetch: 403, API rate limit exceeded"
-  # -> the SDK never installs -> CMake FindZephyr-sdk errors. A token raises the
-  # limit to 5000/hr. Propagates to all jobs (workflow-level env). Uses
-  # github.token (the secrets context is not available at workflow-level env).
+  # Token value for `west sdk install --personal-access-token` (see the install
+  # steps). `west sdk install`'s "Fetching Zephyr SDK list" hits the GitHub API;
+  # anonymous = 60 req/hr per runner IP, and with ~59 concurrent jobs that limit
+  # is blown -> "403 API rate limit exceeded" -> SDK never installs -> CMake
+  # FindZephyr-sdk error. west does NOT read GITHUB_TOKEN from the env (it told
+  # us so: "Try ... --personal-access-token argument or a .netrc file"), so the
+  # steps pass it explicitly; this env just carries the value. github.token is
+  # used because the secrets context is unavailable at workflow-level env.
   GITHUB_TOKEN: ${{ github.token }}
 
 jobs:
@@ -169,7 +170,7 @@ jobs:
           west init -m https://github.com/pulseengine/zephyr.git --mr gale/sem-replacement /mnt/zephyr-workspace
           cd /mnt/zephyr-workspace
           west update --narrow -o=--depth=1
-          for attempt in 1 2 3; do west sdk install -t arm-zephyr-eabi && break || sleep 5; done
+          for attempt in 1 2 3; do west sdk install -t arm-zephyr-eabi --personal-access-token "${GITHUB_TOKEN}" && break || sleep 5; done
 
       - name: Build and run test
         env:
@@ -249,7 +250,7 @@ jobs:
           west init -m https://github.com/pulseengine/zephyr.git --mr gale/sem-replacement /mnt/zephyr-workspace
           cd /mnt/zephyr-workspace
           west update --narrow -o=--depth=1
-          for attempt in 1 2 3; do west sdk install -t arm-zephyr-eabi && break || sleep 5; done
+          for attempt in 1 2 3; do west sdk install -t arm-zephyr-eabi --personal-access-token "${GITHUB_TOKEN}" && break || sleep 5; done
 
       - name: Build and run test
         env:
@@ -349,7 +350,7 @@ jobs:
           west init -m https://github.com/pulseengine/zephyr.git --mr gale/sem-replacement /mnt/zephyr-workspace
           cd /mnt/zephyr-workspace
           west update --narrow -o=--depth=1
-          for attempt in 1 2 3; do west sdk install -t x86_64-zephyr-elf && break || sleep 5; done
+          for attempt in 1 2 3; do west sdk install -t x86_64-zephyr-elf --personal-access-token "${GITHUB_TOKEN}" && break || sleep 5; done
 
       - name: Build and run test
         env:
@@ -410,7 +411,7 @@ jobs:
           west init -m https://github.com/pulseengine/zephyr.git --mr gale/sem-replacement /mnt/zephyr-workspace
           cd /mnt/zephyr-workspace
           west update --narrow -o=--depth=1
-          for attempt in 1 2 3; do west sdk install -t arm-zephyr-eabi && break || sleep 5; done
+          for attempt in 1 2 3; do west sdk install -t arm-zephyr-eabi --personal-access-token "${GITHUB_TOKEN}" && break || sleep 5; done
 
       - name: Setup SDK paths
         run: |

--- a/.github/workflows/zephyr-tests.yml
+++ b/.github/workflows/zephyr-tests.yml
@@ -24,6 +24,14 @@ concurrency:
 env:
   HOME: /root
   DOCKER_CONFIG: /tmp/.docker
+  # Authenticate `west sdk install`'s GitHub API release-list fetch. Without a
+  # token the fetch is anonymous (60 req/hr per runner IP); with ~59 concurrent
+  # jobs all calling it, the limit is blown and jobs fail with
+  #   "Failed to fetch: 403, API rate limit exceeded"
+  # -> the SDK never installs -> CMake FindZephyr-sdk errors. A token raises the
+  # limit to 5000/hr. Propagates to all jobs (workflow-level env). Uses
+  # github.token (the secrets context is not available at workflow-level env).
+  GITHUB_TOKEN: ${{ github.token }}
 
 jobs:
   zephyr-test:


### PR DESCRIPTION
## The "flaky" zephyr-tests are a real CI disk-exhaustion bug

The intermittent zephyr-tests failures are **not flaky tests and not a kernel bug** — the CI runner's root filesystem runs out of space.

### Root cause (evidence-grounded)

The `ci-base` image bundles the **full multi-arch Zephyr SDK** (xtensa/rx/arc/riscv/… under `/opt/toolchains`), which consumes most of the ~14 GB free on the host `/`. Each job then does a west clone + build on top (the x86_64 SMP job rebuilds `core` via `-Zbuild-std`), and unlucky jobs tip over into ENOSPC. The runner crashes writing its own diagnostic log:

```
failure: Unhandled exception. System.IO.IOException: No space left on device :
'/home/runner/actions-runner/cached/.../Worker_*.log'
```

Older runs show the same cause during image unpack:
```
failed to register layer: write /opt/toolchains/zephyr-sdk-1.0.0/.../libc.a: no space left on device
##[error]Docker pull failed with exit code 1
```

### Why it looked flaky

Because it's *whichever job loses the disk race*, the failing **set wanders** across runs — 8 recent `main` runs each red on a different unrelated subset:

| run | failed jobs |
|-----|-------------|
| bc1bff26 | lifo_usage, msgq |
| 40b27421 | mbox_usage, kheap |
| 46547345 | common, event, fifo, Binary size |
| f5fa4cd4 | smp_semaphore, condvar, sched, sched_deadline |
| fa68a392 | smp_*×3, syscalls, fatal_exception |
| … | … |

PR #70's 5 failures all annotate the same ENOSPC runner crash. A changing failing-set across unrelated suites is the disk-race signature, not test non-determinism.

### Fix

Mount the runner's large ephemeral scratch disk (`/mnt`, ~70 GB) into each container and put the west workspace + builds there, off the near-full root fs. Applied to all four jobs (`zephyr-test`, `zephyr-mpu-test`, `zephyr-smp-test`, `size-comparison`).

### Validation

This PR's own zephyr-tests run is the oracle — ENOSPC-class failures should disappear. Crucially, if any test then fails for a **real** reason, it will be **visible** instead of masked by disk-death. (If ENOSPC persists, the next lever is relocating the SDK install / `HOME` off `/` too.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)