### PR TITLE
design(byo-os): gale#74 build-your-own-OS mode — tracked architecture + design doc

### DIFF
--- a/artifacts/byo_os.yaml
+++ b/artifacts/byo_os.yaml
@@ -1,0 +1,271 @@
+# gale "build-your-own OS" (BYO-OS) mode — the architecture behind gale#74.
+#
+# The reframe (from the gust proof + jess's Pixhawk 6X-RT / RT1176 bring-up):
+# gale is not "verified Zephyr primitives" — it is a library of composable,
+# formally-verified OS components, usable two ways:
+#   (1) DROP-IN to an existing OS (zephyr/*.c track; 36 QEMU suites + wasm-dist).
+#   (2) CONSTRUCT-YOUR-OWN OS (gale primitives + kiln-async + async-HAL +
+#       wasm driver/app bodies). gust is the first instance (bare Cortex-M3).
+#
+# This file tracks mode (2) as a first-class capability: the construction crate,
+# the async driver framework (embedded-hal-async seam), the C-free TCB, and the
+# one-OS-three-scales story (M7 falcon / M4 sensor-I/O / F100 gust).
+#
+# Status: PROPOSED — design for discussion on gale#74. gust (gale#65) is the
+# proven minimal instance; this generalizes its hand-rolled scaffold.
+
+artifacts:
+  # ── Stakeholder ───────────────────────────────────────────────────────────
+  - id: STKH-BYOOS-001
+    type: stakeholder-req
+    title: "A C-free, build-your-own RTOS for the flight stack — one verification story, three scales"
+    status: proposed
+    description: >
+      jess (Pixhawk 6X-RT flight stack) needs an RTOS that is not a C kernel
+      (no Zephyr / NuttX / PX4 / NXP-SDK-C in the flight path). The trusted base
+      shall be verified Rust (gale + kiln + HAL) + wasm (Kani-proven drivers +
+      falcon flight logic) — one language discipline and one verification story
+      end-to-end (Verus/Rocq/Lean + Kani), the smallest auditable trusted base,
+      and the SAME OS composed at three scales: M7 (falcon), M4 (sensor-I/O
+      offload), F100 (gust). The only tolerated non-Rust residue is the i.MX boot
+      ROM, which is out of the flight path (on-ground update bootloader only;
+      jess DD-016).
+    tags: [byo-os, c-free, flight, pixhawk, gale74]
+    fields:
+      priority: must
+
+  # ── The reframe finding ───────────────────────────────────────────────────
+  - id: FIND-BYOOS-001
+    type: finding
+    title: "gale is composable OS components (drop-in OR build-your-own), not just Zephyr primitives"
+    status: active
+    description: >
+      gust (gale#65) demonstrated that gale's verified primitives + kiln-async
+      compose into a complete, bootable OS on bare metal with no Zephyr — the
+      kernel as wasm dissolved to native behind a ~4-item native TCB. That makes
+      explicit what gale already is: a library of composable, formally-verified
+      OS *components*, usable two ways — (1) drop-in to an existing OS (the
+      zephyr/*.c track, proven by 36 QEMU kernel-test suites + the wasm-dist
+      modules sem/mutex/msgq), or (2) construct a bespoke OS (gust). The strategic
+      consequence: the C disappears from the flight stack, and gale's positioning
+      shifts from "verified Zephyr primitives" to "composable verified OS
+      components — drop in, or build your own." This finding generates the
+      first-class BYO-OS mode requirement.
+    tags: [byo-os, reframe, gale74, gust]
+    fields:
+      relevance: high
+      action-required: true
+      source: "gust proof (gale#65/#74) + jess RT1176 bring-up; cross-refs gale#63, jess DD-006/DD-011/DD-017"
+    links:
+      - type: generates
+        target: SYSREQ-BYOOS-001
+
+  # ── System requirement ────────────────────────────────────────────────────
+  - id: SYSREQ-BYOOS-001
+    type: system-req
+    title: "gale shall provide a first-class build-your-own-OS construction mode (no Zephyr)"
+    status: proposed
+    description: >
+      gale shall support constructing a complete, bespoke OS from its
+      formally-verified components — gale primitives + the kiln-async executor +
+      an async HAL substrate + wasm driver/app bodies — without requiring Zephyr
+      or any C kernel, as a first-class capability rather than a side effect of
+      the standalone (plain/) track. The construction mode shall scale from a
+      ~4-item-TCB minimal node (gust, F100) to a full async-DMA driver stack
+      (falcon, M7), reusing the same verified component set.
+    tags: [byo-os, gale74]
+    fields:
+      req-type: functional
+      priority: must
+    links:
+      - type: derives-from
+        target: STKH-BYOOS-001
+
+  # ── Software requirements ─────────────────────────────────────────────────
+  - id: REQ-BYOOS-CRATE-001
+    type: sw-req
+    title: "Standalone OS-construction crate: gale core + boot/scheduler-init/device_init scaffold"
+    status: proposed
+    description: >
+      Provide a standalone construction crate (no Zephyr dependency) that
+      composes the gale verified primitives (plain/ track) + the kiln-async
+      executor + a minimal scaffold of construction hooks — reset/boot entry,
+      scheduler init, and device_init ordering — into a runnable OS image. gust's
+      hand-rolled cortex-m-rt + superloop scaffold is the reference minimal
+      instance; this factors that into reusable hooks so a new target is "pick
+      components + provide the TCB shim", not "re-hand-roll the OS".
+    tags: [byo-os, crate, scaffold, gale74]
+    fields:
+      req-type: functional
+      priority: must
+      verification-criteria: >
+        A bare-metal target builds an OS image from the construction crate with
+        no Zephyr in the dependency graph; gust re-expressed on the crate boots
+        on qemu (the existing 5000-poll-round oracle) with an unchanged scheduler
+        result.
+    links:
+      - type: derives-from
+        target: SYSREQ-BYOOS-001
+
+  - id: REQ-BYOOS-DRV-001
+    type: sw-req
+    title: "Async driver framework: embedded-hal-async seam + Embassy-class native HAL + wasm verifiable logic"
+    status: proposed
+    description: >
+      Provide a driver framework for targets needing real async I/O (DMA,
+      IRQ-completion, multiple isolated buses, redundancy) that gust's trivial
+      sync shim does not cover. The seam is the standard `embedded-hal-async`
+      traits; the native host substrate is an Embassy-class async HAL
+      (bus transport + DMA + IRQ-completion), driven by the kiln-async executor
+      (already Embassy-inspired). Verifiable logic — protocol decode (relay,
+      Kani-proven) and redundancy voting — sits ABOVE the async traits in wasm.
+      The split is deliberate: verify what is verifiable (decode/voting) in wasm;
+      reuse battle-tested async-HAL for the timing/DMA that is not easily proven.
+    tags: [byo-os, drivers, embedded-hal-async, embassy, kiln-async, gale74]
+    fields:
+      req-type: interface
+      priority: must
+      verification-criteria: >
+        A driver composed as {wasm decode/voting body} -> embedded-hal-async
+        trait -> native HAL impl drives a peripheral on the RT1176 (or its Renode
+        SVD model) with IRQ->waker completion through kiln-async; the wasm logic
+        body carries its Kani proof, and the native HAL impl is the declared
+        trusted substrate.
+    links:
+      - type: derives-from
+        target: SYSREQ-BYOOS-001
+
+  - id: REQ-BYOOS-CFREE-001
+    type: sw-req
+    title: "C-free trusted base: verified Rust + wasm; only non-Rust residue is the boot ROM (out of flight path)"
+    status: proposed
+    description: >
+      A BYO-OS flight image shall contain no C in the flight path: the trusted
+      base is verified Rust (gale primitives + kiln-async + the async HAL
+      substrate) plus wasm (Kani-proven driver logic + falcon). The only tolerated
+      non-Rust component is the immutable i.MX boot ROM, which is touched only by
+      the on-ground update bootloader, not the flight path (jess DD-016). The
+      verification boundary maps onto the wasm/native seam: verifiable logic is
+      wasm (Verus/Rocq/Lean + Kani), the irreducible-but-thin native substrate
+      (timing/DMA/privileged ops) is the declared TCB.
+    tags: [byo-os, c-free, tcb, gale74]
+    fields:
+      req-type: constraint
+      priority: must
+      verification-criteria: >
+        `nm <flight.elf>` shows no C-runtime/SDK symbols in the flight path; the
+        only non-Rust object is the boot ROM (not linked into the flight image).
+    links:
+      - type: derives-from
+        target: SYSREQ-BYOOS-001
+
+  - id: REQ-BYOOS-SCALE-001
+    type: sw-req
+    title: "One OS, three scales: M7 (falcon) / M4 (sensor-I/O) / F100 (gust) from the same components"
+    status: proposed
+    description: >
+      The same verified component set + construction crate shall target three
+      scales by varying only the TCB shim and the synth target: M7 (falcon, full
+      async-DMA driver stack), M4 (sensor-I/O offload), and F100 (gust, ~4-item
+      sync TCB). Retarget = re-synth the wasm bodies to the new ISA + swap the
+      per-SoC TCB — proven in miniature by the gust kernel re-synthing to
+      cortex-m3 AND riscv32 from one wasm.
+    tags: [byo-os, portability, three-scale, gale74]
+    fields:
+      req-type: functional
+      priority: should
+      verification-criteria: >
+        The construction crate builds a bootable image for at least two distinct
+        targets (e.g. F100/gust and an M7/M4 RT1176 profile) from the same
+        component set, differing only in the TCB shim + synth --target.
+    links:
+      - type: derives-from
+        target: SYSREQ-BYOOS-001
+
+  # ── Architecture: the BYO-OS layer cake ───────────────────────────────────
+  - id: SAC-BYOOS-SCAFFOLD
+    type: sw-arch-component
+    title: "Construction scaffold + thin native TCB (boot/reset, scheduler-init, device_init hooks)"
+    status: proposed
+    description: >
+      The bottom layer: vector table + reset, scheduler init, device_init
+      ordering, and the per-SoC native TCB shim (privileged ops, MMIO, IRQ entry).
+      Pure Rust (cortex-m-rt class), no C. gust's scaffold is the reference; this
+      component factors it into reusable construction hooks.
+    tags: [byo-os, scaffold, tcb, gale74]
+    fields:
+      concurrency: "single-core superloop (gust) up to IRQ-driven (M7); privileged ops are the TCB boundary"
+    links:
+      - type: allocated-from
+        target: REQ-BYOOS-CRATE-001
+
+  - id: SAC-BYOOS-EXEC
+    type: sw-arch-component
+    title: "kiln-async executor (fuel-bounded cooperative scheduler, Embassy-inspired)"
+    status: proposed
+    description: >
+      The executor layer: kiln-async's no_std/no_alloc fuel-bounded cooperative
+      scheduler (task arena + waker-as-index, citing embassy-executor). Hosts both
+      the application tasks and the async driver tasks; the fuel bound is the WCET
+      unit (spar RTA/EDF). Deferred work is a kiln-async task — NOT a separate
+      Zephyr-style workqueue (that would duplicate the executor).
+    tags: [byo-os, kiln-async, executor, wcet, gale74]
+    fields:
+      concurrency: "cooperative, fuel-bounded; one task dispatched per poll_round (O(1))"
+    links:
+      - type: allocated-from
+        target: REQ-BYOOS-DRV-001
+
+  - id: SAC-BYOOS-HALSEAM
+    type: sw-arch-component
+    title: "embedded-hal-async trait seam + Embassy-class native HAL substrate (IRQ->waker)"
+    status: proposed
+    description: >
+      The driver seam: standard `embedded-hal-async` traits as the contract.
+      Below the traits, the native Embassy-class async HAL (bus transport, DMA,
+      IRQ-completion) — the trusted substrate for the timing/DMA that is not
+      easily proven; IRQ handlers wake kiln-async tasks via the standard Waker.
+      Above the traits, only verifiable logic (next component). This is the
+      "full-fat gust seam" (gust's sync MMIO shim, generalized to async+DMA;
+      jess DD-012/DD-015). The RT1176 PAC (svd2rust from the BSD-3 CMSIS-SVD)
+      is the register foundation; Renode ApplySVD gives the hermetic HIL.
+    tags: [byo-os, embedded-hal-async, embassy, dma, rt1176, gale74]
+    fields:
+      interfaces: {seam: "embedded-hal-async traits", below: "Embassy-class native HAL (DMA/IRQ)", pac: "svd2rust RT1176"}
+      concurrency: "async; IRQ-completion -> Waker -> kiln-async task"
+    links:
+      - type: allocated-from
+        target: REQ-BYOOS-DRV-001
+
+  - id: SAC-BYOOS-WASMLOGIC
+    type: sw-arch-component
+    title: "Verifiable wasm logic above the traits (Kani-proven protocol decode + redundancy voting)"
+    status: proposed
+    description: >
+      The verifiable layer: protocol decode (relay, Kani-proven) and redundancy
+      voting sit ABOVE the embedded-hal-async traits as wasm bodies (meld -> loom
+      -> synth dissolved, like the gust kernel). This is where the verification
+      lives; the async HAL beneath is trusted-but-not-proven. The split realises
+      "verify what is verifiable, reuse battle-tested for what you cannot prove".
+    tags: [byo-os, wasm, kani, relay, voting, gale74]
+    fields:
+      concurrency: "logic only (no timing); driven by the executor through the trait seam"
+    links:
+      - type: allocated-from
+        target: REQ-BYOOS-DRV-001
+
+  - id: SAC-BYOOS-PRIMS
+    type: sw-arch-component
+    title: "gale verified primitives (sem/mutex/msgq/event/poll/device_init) — drop-in or composed"
+    status: proposed
+    description: >
+      The component library: gale's formally-verified primitives (Verus/Rocq/Lean
+      + Kani), usable drop-in (zephyr/*.c) OR composed into the BYO-OS. For the
+      async driver framework, `device_init` (bring-up ordering) and `poll`
+      (waitable-set readiness, mirrored by kiln-async's waitable-set/stream) are
+      the reused verified hooks; `work` (Zephyr workqueue) is intentionally NOT
+      reused (kiln-async is the executor).
+    tags: [byo-os, primitives, device_init, poll, gale74]
+    links:
+      - type: allocated-from
+        target: REQ-BYOOS-CFREE-001

--- a/artifacts/byo_os_lifecycle.yaml
+++ b/artifacts/byo_os_lifecycle.yaml
@@ -81,15 +81,24 @@ artifacts:
       The sharp consequence of the verification/replay cut being the SAME seam: a
       replay that DIVERGES from the verified component's behaviour localizes the bug to
       EITHER the native TCB (the declared unverified part) OR an unmodeled hardware
-      behaviour — never the verified logic (which is proven). Record-replay (rr,
-      Pernosco) and embedded trace (Tracealyzer, SystemView) exist, but as x86
-      time-travel or trace-VIEW; deterministic *re-execution of the same verified,
-      dissolvable component* at the verification seam is the unoccupied combination.
-    tags: [byo-os, record-replay, debugging, time-travel, tcb-seam, gale74]
+      behaviour — never the verified logic (which is proven).
+
+      PRIOR ART (frontier sweep, DOC-WASM-FRONTIER — do NOT pitch the mechanism as
+      novel): import-boundary record + cross-engine replay is already published —
+      **Wasm-R3** (OOPSLA 2024) records the host-import trace, reduces it ~99.5%, and
+      replays on any engine; CMU is building Wasmtime time-travel debugging; Wasmtime
+      itself is adding record/replay WIT interfaces. So gale ADOPTS the Wasm-R3
+      recorder design rather than inventing it. gale's genuine, unclaimed delta is
+      twofold: (1) a **bare-metal/MCU record backend** (Wasm-R3/CMU record in
+      browser/host, not on a dissolved-native device), and (2) **divergence-localization**
+      — because the same artifact is formally verified, an identical-tape divergence
+      provably excludes the verified logic (theoretically backed by Iris-Wasm's
+      robust-safety boundary, PLDI 2023). LEAD WITH (2), not "record-replay".
+    tags: [byo-os, record-replay, debugging, divergence-localization, wasm-r3, tcb-seam, gale74]
     fields:
       relevance: high
       action-required: true
-      source: "gust TCB seam; the import surface is the verification boundary (DOC-BYOOS-ARCH)"
+      source: "gust TCB seam = verification boundary (DOC-BYOOS-ARCH); prior art Wasm-R3 OOPSLA'24 (DOC-WASM-FRONTIER)"
     links:
       - type: generates
         target: REQ-BYOOS-REPLAY-001

--- a/artifacts/byo_os_lifecycle.yaml
+++ b/artifacts/byo_os_lifecycle.yaml
@@ -196,3 +196,38 @@ artifacts:
     links:
       - type: derives-from
         target: SYSREQ-BYOOS-001
+
+  # ── The uniqueness the frontier sweep underweighted: the device class ──────
+  - id: FIND-BYOOS-005
+    type: finding
+    title: "CM + an OS authored in wasm, on the sub-runtime device class WAMR cannot reach, is genuinely unoccupied"
+    status: active
+    description: >
+      The frontier sweep (DOC-WASM-FRONTIER) correctly found that individual
+      ingredients are prior art (record-replay = Wasm-R3; dissolve = wasm2c/w2c2;
+      wasm-on-MCU = WAMR). But it underweighted the DEVICE CLASS, which is where gale
+      is genuinely alone:
+        - WAMR — the de-facto "wasm on MCU" — keeps a RESIDENT runtime/loader
+          (~50-64 KB code + per-module RAM). Its floor is far above gust's 8 KB SRAM /
+          ~4-function-TCB / ZERO-runtime target. WAMR (and AkiraOS/esp-wdf) do not aim
+          at this class; they cannot, without a runtime on the device.
+        - The WebAssembly Component Model runs in cloud/edge/host runtimes. NOBODY runs
+          CM on bare-metal MCUs at all — and certainly not a CM-composed OS dissolved to
+          native on an 8 KB node.
+        - gust is an OS *authored in wasm* (kiln-async kernel + primitives), composed and
+          dissolved (meld/loom/synth) to native, booting on 8 KB with no runtime.
+      So the unoccupied intersection is not just "verified + dissolved" — it is
+      "Component-Model-composed, wasm-authored OS, on the sub-runtime (<=~16 KB, no
+      resident runtime) device class". WAMR being the universally-cited incumbent makes
+      this STRONGER, not weaker: the thing everyone points to for "wasm on MCU"
+      structurally stops above where gale lives. Do not let the prior-art on individual
+      ingredients talk down the conjunction at this device class — but do keep citing
+      the prior art honestly (the two are not in tension).
+    tags: [byo-os, device-class, wamr, component-model, no-runtime, uniqueness, gale74]
+    fields:
+      relevance: high
+      action-required: false
+      source: "frontier sweep WAMR footprint data (DOC-WASM-FRONTIER); gust = 8KB no-runtime (project_gust_mini_os)"
+    links:
+      - type: related-to
+        target: SYSREQ-BYOOS-001

--- a/artifacts/byo_os_lifecycle.yaml
+++ b/artifacts/byo_os_lifecycle.yaml
@@ -1,0 +1,189 @@
+# gale BYO-OS — the wasm-as-universal-substrate lifecycle + a second vertical (wohl).
+#
+# Out-of-the-box extension of gale#74: because gale authors components as wasm and
+# only *then* dissolves them to native, the wasm is not merely a build IR — it is the
+# universal substrate for the WHOLE lifecycle. The same formally-verified component
+# runs in (a) the browser, (b) a host runtime (wasmtime / kiln) for test, and (c)
+# dissolved-to-native on hardware. The narrow wasm/TCB import seam — which is already
+# the *verification* cut — doubles as a *record-replay* cut: capture the import tape
+# on hardware, replay it deterministically in wasmtime/browser, and step a hardware
+# bug in a host time-travel debugger.
+#
+# Honest novelty (per the market sweep, DOC-BYOOS-MARKET): every ingredient exists —
+# wasm-in-browser, host wasm testing, record-replay (rr/Pernosco), OTA-wasm
+# (WAMR/WasmEdge). gale's differentiator is the CONJUNCTION on a single
+# formally-verified, dissolvable component: one artifact across browser/host/HW, with
+# the verification-cut = the record-replay-cut. The columns are owned; the
+# intersection is not.
+
+artifacts:
+  # ── Second vertical: home automation (wohl) ───────────────────────────────
+  - id: STKH-WOHL-001
+    type: stakeholder-req
+    title: "wohl (home automation): low cost + few battery cycles, OTA-updatable, browser-simulable"
+    status: proposed
+    description: >
+      wohl (home automation) is a second target vertical alongside drones, with the
+      same pressures that make gale attractive there: low unit cost (smallest MCU),
+      few battery cycles (sleep-heavy, intermittent, multi-year field life), and
+      wireless OTA update over the device lifetime. A home-automation node wants the
+      same composable verified components as a drone, scaled DOWN: a tiny dissolved
+      footprint, a fuel-bounded scheduler that makes sleep timing predictable (battery
+      win), an OTA path where the update unit is a signed, re-verifiable wasm
+      component, and a browser-simulable dev/demo experience.
+    tags: [wohl, home-automation, byo-os, battery, ota, gale74]
+    fields:
+      priority: should
+
+  # ── wasm as the universal lifecycle substrate ─────────────────────────────
+  - id: FIND-BYOOS-002
+    type: finding
+    title: "One verified component, three runtimes: browser + host (wasmtime/kiln) + dissolved-native"
+    status: active
+    description: >
+      Because gale authors components as wasm and dissolves them to native only at the
+      end, the SAME formally-verified component executes unmodified across the whole
+      lifecycle: in the browser (interactive docs/demos, a visual scheduler/ring-buffer
+      inspector, browser-as-HIL against a simulated peripheral model), on a host runtime
+      (wasmtime/kiln) for fast functional + differential testing and fuzzing, and
+      dissolved-to-native on the MCU for ship. gale already does the host leg (the
+      wasm-testbed runs wasmtime --invoke + a 3-way wasmtime/unicorn-arm/rv32
+      differential); the browser leg and a first-class "run gust in your browser" are
+      the obvious extension. The neighbours cannot do this: the dissolved-native field
+      (aWsm) discards the wasm; the on-device-runtime field (WAMR) keeps an interpreter
+      and never dissolves. gale uniquely keeps BOTH forms of one verified artifact.
+    tags: [byo-os, wasm-substrate, browser, wasmtime, kiln, gale74]
+    fields:
+      relevance: high
+      action-required: true
+      source: "gust + wasm-testbed (host leg shipping); DOC-BYOOS-MARKET (ingredients owned, conjunction not)"
+    links:
+      - type: generates
+        target: REQ-BYOOS-MULTIRT-001
+      - type: related-to
+        target: STKH-WOHL-001
+
+  # ── HW -> wasmtime record-replay debugging ────────────────────────────────
+  - id: FIND-BYOOS-003
+    type: finding
+    title: "Import-tape record-replay: capture on HW, replay deterministically in wasmtime/browser"
+    status: active
+    description: >
+      The wasm/TCB import seam is narrow (the ~4-function TCB: MMIO reads, IRQ events,
+      timer ticks, bus bytes) AND it is exactly where all non-determinism enters a
+      gale component — the verified logic above it is deterministic. That makes the seam
+      the natural record-replay cut: on hardware, capture the "tape" of import values
+      the component consumes; replay that tape into the SAME wasm component in
+      wasmtime/browser and get bit-identical execution. A hardware heisenbug (M7/M4 or
+      a sleepy wohl node, where JTAG/printf debugging is painful) becomes a
+      deterministic, steppable, time-travel-debuggable host session.
+
+      The sharp consequence of the verification/replay cut being the SAME seam: a
+      replay that DIVERGES from the verified component's behaviour localizes the bug to
+      EITHER the native TCB (the declared unverified part) OR an unmodeled hardware
+      behaviour — never the verified logic (which is proven). Record-replay (rr,
+      Pernosco) and embedded trace (Tracealyzer, SystemView) exist, but as x86
+      time-travel or trace-VIEW; deterministic *re-execution of the same verified,
+      dissolvable component* at the verification seam is the unoccupied combination.
+    tags: [byo-os, record-replay, debugging, time-travel, tcb-seam, gale74]
+    fields:
+      relevance: high
+      action-required: true
+      source: "gust TCB seam; the import surface is the verification boundary (DOC-BYOOS-ARCH)"
+    links:
+      - type: generates
+        target: REQ-BYOOS-REPLAY-001
+
+  # ── wohl as an application of BYO-OS ───────────────────────────────────────
+  - id: FIND-BYOOS-004
+    type: finding
+    title: "Home automation (wohl) is a second BYO-OS vertical — same components, scaled down + OTA"
+    status: active
+    description: >
+      The drone (PX4/M7) and home-automation (wohl) verticals share the BYO-OS value:
+      verified composable components, tiny dissolved footprint, fuel-bounded WCET. wohl
+      adds two emphases — battery (the fuel bound makes wake/sleep timing predictable,
+      so the node sleeps maximally and deterministically) and OTA (ship a signed,
+      re-verifiable wasm component as the update unit; re-dissolve on-device or ship
+      dissolved). This widens gale's market beyond safety-critical into cost/power-
+      critical, on the SAME component library.
+    tags: [wohl, home-automation, byo-os, battery, ota, gale74]
+    fields:
+      relevance: medium
+      action-required: false
+      source: "user direction 2026-06-20; STKH-WOHL-001"
+    links:
+      - type: generates
+        target: REQ-WOHL-001
+      - type: related-to
+        target: STKH-WOHL-001
+
+  # ── Requirements ──────────────────────────────────────────────────────────
+  - id: REQ-BYOOS-MULTIRT-001
+    type: sw-req
+    title: "The same verified wasm component shall run + be tested across browser, host (wasmtime/kiln), and dissolved-native"
+    status: proposed
+    description: >
+      A gale component (and a composed BYO-OS such as gust) shall be runnable from a
+      single wasm source in three environments — browser (wasm), host runtime
+      (wasmtime/kiln), and dissolved-to-native (synth) — with a test harness that
+      exercises the same vectors across all three and asserts functional equivalence
+      (extending the existing wasmtime/unicorn-arm/rv32 differential). A "run gust in
+      the browser" demo is the first browser-leg deliverable.
+    tags: [byo-os, multi-runtime, browser, test, gale74]
+    fields:
+      req-type: functional
+      priority: should
+      verification-criteria: >
+        A composed component produces identical results for a vector set run in
+        (a) wasmtime, (b) a browser wasm host, and (c) the synth-dissolved native
+        object (on qemu/Renode); divergence fails the harness.
+    links:
+      - type: derives-from
+        target: SYSREQ-BYOOS-001
+
+  - id: REQ-BYOOS-REPLAY-001
+    type: sw-req
+    title: "Capture the wasm/TCB import tape on hardware and deterministically replay it in wasmtime/browser"
+    status: proposed
+    description: >
+      The construction scaffold shall support capturing, on hardware, the sequence of
+      values crossing the wasm/TCB import seam (MMIO reads, IRQ/timer events, bus
+      bytes), and replaying that tape into the same wasm component in wasmtime/browser
+      to reproduce execution bit-identically for debugging. Because the seam is the
+      verification cut, a replay divergence shall localize a fault to the native TCB or
+      to unmodeled hardware, never to the verified logic.
+    tags: [byo-os, record-replay, debugging, tcb-seam, gale74]
+    fields:
+      req-type: functional
+      priority: could
+      verification-criteria: >
+        A recorded HW import tape replayed in wasmtime reproduces the on-HW
+        component output exactly; an injected TCB/hardware fault shows up as a replay
+        divergence pinned to the seam, not the verified body.
+    links:
+      - type: derives-from
+        target: SYSREQ-BYOOS-001
+
+  - id: REQ-WOHL-001
+    type: sw-req
+    title: "BYO-OS shall scale to a battery/cost-critical home-automation node (predictable sleep + OTA wasm)"
+    status: proposed
+    description: >
+      The component library + construction crate shall target a low-cost, battery-
+      powered home-automation node: minimal dissolved footprint, a fuel-bounded
+      scheduler whose bound makes wake/sleep timing predictable (maximize deep-sleep
+      residency), and an OTA path where the signed wasm component is the re-verifiable
+      update unit. Demonstrates gale beyond safety-critical, into cost/power-critical,
+      on the same components.
+    tags: [wohl, home-automation, battery, ota, byo-os, gale74]
+    fields:
+      req-type: functional
+      priority: could
+      verification-criteria: >
+        A wohl-class node image builds from the construction crate; the scheduler's
+        fuel bound yields a documented worst-case wake interval (sleep budget); an OTA
+        wasm component update is sigil-signed and re-verifiable.
+    links:
+      - type: derives-from
+        target: SYSREQ-BYOOS-001

--- a/docs/byo-os-architecture.md
+++ b/docs/byo-os-architecture.md
@@ -133,3 +133,55 @@ carries the same gaps gust surfaced, now at async scale:
 - **The synth toolchain in the TCB** — trust/qualification story (cf. `FIND-GUST-004`).
 
 These are tracked as gust findings and apply identically to the BYO-OS driver framework.
+
+## wasm as the universal lifecycle substrate (not just a build IR)
+
+Because gale authors components as wasm and dissolves them to native *only at the end*,
+the wasm is the substrate for the **whole lifecycle** — one formally-verified artifact,
+three runtimes:
+
+```mermaid
+flowchart LR
+  SRC["verified component (Rust -> wasm)\nproven: Verus/Rocq/Lean/Kani"]
+  SRC --> BR["Browser (wasm)\ndocs/demos · visual inspector · browser-as-HIL"]
+  SRC --> HOST["Host runtime: wasmtime / kiln\nfunctional + 3-way differential test · fuzz · debug"]
+  SRC --> HW["Dissolved native (synth)\nships on M7 / M4 / M3 / RISC-V"]
+  HW -. "import tape (MMIO/IRQ/timer) recorded at the TCB seam" .-> HOST
+```
+
+- **Browser** — run a component (or a whole gust) unmodified in a browser: interactive
+  docs, a steppable scheduler/ring-buffer inspector, browser-as-HIL against a simulated
+  peripheral. (`FIND-BYOOS-002`)
+- **Host (wasmtime / kiln)** — already shipping: the wasm-testbed runs `wasmtime --invoke`
+  + the 3-way wasmtime/unicorn-arm/rv32 differential. Fast functional test, fuzzing, and
+  host debugging of the *same* component that ships. (`REQ-BYOOS-MULTIRT-001`)
+- **Dissolved native** — `synth` to bare metal, ships.
+
+The neighbours can't do this: the dissolved-native field (aWsm) *discards* the wasm; the
+on-device-runtime field (WAMR) keeps an interpreter and *never dissolves*. gale keeps both
+forms of one verified artifact (see `DOC-BYOOS-MARKET`).
+
+### The debug superpower: record on HW, replay in wasmtime (`FIND-BYOOS-003`)
+
+The wasm/TCB **import seam is narrow and is exactly where all non-determinism enters** —
+the verified logic above it is deterministic. So the seam is a natural **record-replay cut**:
+capture the tape of import values on hardware (MMIO reads, IRQ/timer events, bus bytes),
+replay it into the *same* wasm component in wasmtime/browser, and re-execute bit-identically.
+A hardware heisenbug (an M7 DMA race, or a sleepy wohl node where JTAG/printf is painful)
+becomes a steppable, time-travel-debuggable host session.
+
+**The elegant part: the record-replay cut == the verification cut.** A replay that diverges
+from the proven component's behaviour localizes the fault to the **native TCB** (the declared
+unverified part) or to **unmodeled hardware** — *never* to the verified logic. record-replay
+(rr, Pernosco) and embedded trace (Tracealyzer, SystemView) exist, but as x86 time-travel or
+trace-*view*; deterministic re-execution of the same verified, dissolvable component at the
+verification seam is the unoccupied combination. (`REQ-BYOOS-REPLAY-001`)
+
+## Second vertical: wohl (home automation) (`STKH-WOHL-001` / `FIND-BYOOS-004`)
+
+Drones and home automation share the BYO-OS value, with wohl emphasising **cost + battery**:
+the smallest dissolved footprint on the cheapest MCU, a **fuel-bounded scheduler whose bound
+makes wake/sleep timing predictable** (so the node sleeps maximally and deterministically —
+a direct battery win), and **OTA where the update unit is a signed, re-verifiable wasm
+component**. Same component library, scaled down — widening gale from safety-critical into
+cost/power-critical. (`REQ-WOHL-001`)

--- a/docs/byo-os-architecture.md
+++ b/docs/byo-os-architecture.md
@@ -1,0 +1,135 @@
+---
+id: DOC-BYOOS-ARCH
+title: "gale build-your-own OS (BYO-OS) — composable verified OS components, C-free"
+type: documentation
+status: proposed
+tags: [byo-os, gale74, c-free, embedded-hal-async, kiln-async, gust, three-scale]
+links:
+  - type: related-to
+    target: FIND-BYOOS-001
+  - type: related-to
+    target: SYSREQ-BYOOS-001
+  - type: related-to
+    target: REQ-BYOOS-CRATE-001
+  - type: related-to
+    target: REQ-BYOOS-DRV-001
+  - type: related-to
+    target: REQ-BYOOS-CFREE-001
+  - type: related-to
+    target: REQ-BYOOS-SCALE-001
+  - type: related-to
+    target: SAC-BYOOS-SCAFFOLD
+  - type: related-to
+    target: SAC-BYOOS-EXEC
+  - type: related-to
+    target: SAC-BYOOS-HALSEAM
+  - type: related-to
+    target: SAC-BYOOS-WASMLOGIC
+  - type: related-to
+    target: SAC-BYOOS-PRIMS
+---
+
+# gale build-your-own OS (BYO-OS)
+
+> The reframe (gale#74): **gale is not "verified Zephyr primitives" — it is a library of
+> composable, formally-verified OS components.** Drop them into an existing OS, *or* build
+> your own. `gust` proved the second mode; this is its generalisation.
+
+## Two modes, one component library
+
+| mode | what it is | proven by |
+|------|-----------|-----------|
+| **Drop-in** | gale replaces an existing OS's C kernel primitives in place (`zephyr/*.c`) | 36 QEMU kernel-test suites + wasm-dist modules (sem/mutex/msgq) |
+| **Build-your-own** | compose gale primitives + kiln-async + async HAL + wasm bodies into a bespoke OS — no Zephyr | `gust` boots on bare Cortex-M3 (`gale#65`) |
+
+The payoff jess wants (Pixhawk 6X-RT): in build-your-own mode **the C disappears** — no Zephyr,
+no NuttX/PX4, no NXP-SDK C drivers. The flight trusted base becomes **verified Rust (gale + kiln
++ HAL) + wasm (Kani-proven drivers + falcon)**: one language discipline, one verification story
+end-to-end (Verus/Rocq/Lean + Kani), the smallest auditable trusted base.
+
+## The layer cake
+
+```mermaid
+flowchart TB
+  APP["Application — wasm, dissolved (failsafe / falcon flight logic)"]
+  LOGIC["Verifiable logic — wasm, Kani-proven (relay decode + redundancy voting) · SAC-BYOOS-WASMLOGIC"]
+  SEAM["embedded-hal-async traits — THE SEAM"]
+  HAL["Embassy-class native async HAL — DMA / bus / IRQ-completion · SAC-BYOOS-HALSEAM"]
+  EXEC["kiln-async executor — fuel-bounded cooperative scheduler · SAC-BYOOS-EXEC"]
+  PRIMS["gale verified primitives — sem/mutex/msgq/event/poll/device_init · SAC-BYOOS-PRIMS"]
+  SCAFFOLD["Construction scaffold + thin native TCB — boot/reset, sched-init, device_init, MMIO, IRQ entry · SAC-BYOOS-SCAFFOLD"]
+  HW["Hardware (M7 / M4 / F100)"]
+
+  APP --> LOGIC --> SEAM
+  SEAM --> HAL
+  LOGIC -.driven by.-> EXEC
+  HAL --> EXEC
+  EXEC --> PRIMS
+  PRIMS --> SCAFFOLD
+  HAL --> SCAFFOLD
+  SCAFFOLD --> HW
+```
+
+**The verification boundary IS the wasm/native seam.** Everything *above* `embedded-hal-async`
+is verifiable logic → wasm (proven + dissolved). Everything *below* is timing/DMA/privileged
+state you cannot easily prove → the trusted native substrate. That is the same boundary `gust`
+drew for its sync MMIO shim, generalised to async + DMA.
+
+## Answers to the three asks (gale#74)
+
+### 1. First-class build-your-own mode? — **Yes.**
+gust already proves it works on bare metal. Make it first-class via a **construction crate**
+(`SAC-BYOOS-SCAFFOLD` / `REQ-BYOOS-CRATE-001`): the `plain/` gale primitives + kiln-async + a
+minimal reusable scaffold (reset/boot, scheduler-init, `device_init` ordering), no Zephyr. gust's
+hand-rolled cortex-m-rt superloop becomes the reference minimal instance, factored into hooks —
+so a new target is "pick components + provide the TCB shim", not "re-hand-roll the OS".
+
+### 2. Are `device_init` / `work` / `poll` the right hooks? — **Two yes, one no.**
+- **`device_init` — yes.** It is the verified bring-up-ordering primitive; it is the construction
+  scaffold's device-init hook.
+- **`poll` — yes.** Its verified waitable-set readiness logic maps onto async readiness/select;
+  kiln-async's `waitable-set`/`stream` already echo `k_poll`. Reuse it for the readiness layer.
+- **`work` — no (redundant).** kiln-async *is* the executor; a Zephyr-style workqueue on top of
+  it duplicates it. Deferred work is a kiln-async task.
+- **The driver framework itself is a thin NEW layer** (`SAC-BYOOS-HALSEAM`), anchored on
+  `embedded-hal-async`, hosted on kiln-async — not routed through `work`.
+
+### 3. Positioning "composable OS components (drop-in or BYO), C-free"? — **Yes, and accurate.**
+Both modes are *proven* (drop-in: 36 suites + wasm-dist; BYO: gust). The README story shifts from
+"verified Zephyr primitives" to **"composable verified OS components — drop into an existing OS,
+or build your own; C-free Rust + wasm."** This matches the gust/jess trajectory (DD-006 maximal-wasm
+/ DD-011 gust / DD-017 M7 = gale-maximal-wasm) and is the Bytecode-Alliance-resonant framing.
+
+## The driver model (the sophisticated piece)
+
+gust's driver model is a trivial ~4-item sync shim. The M7 needs the real thing — DMA, async
+completion, multiple isolated buses, redundancy. The substrate (`REQ-BYOOS-DRV-001`):
+
+- **Seam:** `embedded-hal-async` (standard async embedded-HAL traits).
+- **Native host substrate:** Embassy-class async HAL (bus transport + DMA + IRQ-completion) —
+  "drivers as host components, driven down". IRQ handlers wake kiln-async tasks via `Waker`.
+- **Executor:** kiln-async (already Embassy-inspired — task arena + waker-as-index).
+- **Verifiable logic stays wasm:** relay's Kani-proven protocol decode + redundancy voting sit
+  *above* the async traits.
+
+Enabler: the **MIMXRT1176 CMSIS-SVD** (NXP official, BSD-3-Clause, cm7+cm4) → `svd2rust` PAC for
+the HAL foundation **and** Renode `ApplySVD` for the hermetic HIL — one artifact unblocks both
+the real-silicon HAL and emulation, M7 and M4.
+
+## One OS, three scales (`REQ-BYOOS-SCALE-001`)
+
+The same component set targets **M7 (falcon, full async-DMA stack) / M4 (sensor-I/O offload) /
+F100 (gust, ~4-item sync TCB)** by varying only the TCB shim and the synth `--target`. Proven in
+miniature: the gust kernel re-synths from one `.wasm` to **cortex-m3 AND riscv32**.
+
+## Honest open rigor (inherited from gust, at async scale)
+
+The async HAL substrate (Embassy-class) is the **trusted, not-proven** layer — timing/DMA. It
+carries the same gaps gust surfaced, now at async scale:
+- **WCET of the native substrate** (IRQ entry/exit + DMA-completion latency) is outside the fuel
+  model — bound separately (cf. `FIND-GUST-002`).
+- **IRQ→waker concurrency** (the cross-context wake) needs a lost-wakeup/torn-read proof
+  (cf. `FIND-GUST-003`).
+- **The synth toolchain in the TCB** — trust/qualification story (cf. `FIND-GUST-004`).
+
+These are tracked as gust findings and apply identically to the BYO-OS driver framework.

--- a/docs/byo-os-market-research.md
+++ b/docs/byo-os-market-research.md
@@ -1,0 +1,128 @@
+---
+id: DOC-BYOOS-MARKET
+title: "gale BYO-OS — market & research positioning (sweep, 2026-06-20)"
+type: documentation
+status: proposed
+tags: [byo-os, gale74, market-research, positioning, novelty]
+links:
+  - type: related-to
+    target: FIND-BYOOS-001
+  - type: related-to
+    target: DOC-BYOOS-ARCH
+---
+
+> **Source:** 7-dimension parallel research workflow (8 agents, 104 web lookups), 2026-06-20.
+> **Maintainer correction (status of the proof-carrying pipeline):** the report cites
+> `synth#167` (from a stale memory note) as the pipeline being non-linkable. That is
+> outdated — the gust scout has since PROVEN hot-path dissolution: the kiln-async
+> scheduler `gust_poll` dissolves wasm→loom→synth to **812 B of linkable Cortex-M3**
+> (and re-targets to RISC-V from the same wasm). The *current* open links are
+> synth#382 (fixed in v0.11.50) and synth#383 (`.bss` sizing, open) — not #167. So
+> recommendation #1 ("validate the pipeline end-to-end") is **further along than the
+> report implies**: hot path proven; remaining gap is the on-MCU `.bss` link (#383)
+> and carrying the *proofs* through fusion (the genuinely open research claim).
+
+# gale / gust: Market & Research Positioning
+
+## 1. Executive summary
+
+- **Where gale sits:** gale occupies the empty intersection of three mature-but-separate lineages — (a) compositional verified-OS construction (CertiKOS/DeepSpec, seL4), (b) Rust+Verus verified kernels (Atmosphere, Tock/TickTock), and (c) no-runtime wasm-to-bare-metal AOT (aWsm, w2c2). Every neighbor owns one column; **no surveyed project owns the intersection.**
+- **The one genuine differentiator:** authoring the OS kernel primitives *themselves* (sem/mutex/msgq/event/poll/scheduler) as WebAssembly, machine-checking them across multiple backends (Verus+Rocq+Lean+Kani), then statically **fusing (meld) + inlining (loom) + AOT-compiling (synth)** the wasm *away* into bare-metal native with a ~4-function TCB. The entire rest of the field treats wasm as an *app sandbox running on top of* a native kernel — the inverse of gale's intent. This "proof-carrying wasm-fusion-to-firmware" pipeline is simultaneously gale's biggest moat and its least externally-validated, partly-unshipped piece (synth#167 arm backend was emitting non-linkable placeholders per project memory).
+- **The biggest threat:** the "certified open-source OS *without* machine-checked proofs" wave. If **Zephyr** lands IEC 61508 SIL 3 / ISO 26262 ASIL D (concept approval done; artifacts 2026–27) and **Auterion** ships DO-178 PX4 Pro, the market may judge process-evidence certification "good enough," making gale's proof premium a hard sell unless it *also* cuts cert-evidence cost. The secondary structural threat: **aWsm/eWASM (GWU)** already ships the exact codegen mechanic (wasm→LLVM-LTO→Cortex-M .o, no interpreter) and is attached to an OS group (Composite); if they author primitives in wasm and add proofs, they close the gap fastest.
+- **Honest novelty boundary:** none of gale's *individual* ingredients are novel — composition (wac), no-runtime AOT (w2c2/aWsm), verified Rust kernels (Atmosphere/Tock), HAL-in-wasm/timing-in-native seam (Wasm-IO, EMSOFT 2025), and verified wasm semantics (WasmCert) all have credible owners. The moat is the *combination*, not any column.
+
+## 2. Landscape map
+
+| Dimension | Closest player(s) | URL | How close to gale | Key gap vs gale |
+|---|---|---|---|---|
+| wasm-on-MCU (no-runtime AOT) | aWsm / eWASM (GWU) | github.com/gwsystems/aWsm | **Very close (mechanism)** | App SFI sandbox, not kernel-as-wasm; C runtime LTO'd in (not C-free); no proofs; no component fusion |
+| | WAMR (BCA) | github.com/bytecodealliance/wasm-micro-runtime | Far | Keeps ~50K on-device runtime/loader; wasm = app layer on native RTOS |
+| | Mewz unikernel | github.com/mewz-project/mewz | Medium (build-your-own idea) | x86 cloud on QEMU; native Zig scaffolding; no MCU; no proofs |
+| Component-model fusion | wac (BCA) | github.com/bytecodealliance/wac | **Close (fusion axis)** | Halts at composed .wasm; no inlining, no native, no proofs; cloud-oriented |
+| | w2c2 / wasm2c | github.com/turbolent/w2c2 | **Close (no-runtime axis)** | Per-module (no component fusion); emits C; no verification |
+| | wac → wasmtime compile → .cwasm | docs.wasmtime.dev | Closest *shipping* end-to-end | Run by heavyweight Wasmtime/Cranelift host runtime, not a ~4-fn TCB |
+| Verified OS (composition) | CertiKOS / DeepSpec layers | flint.cs.yale.edu/certikos | **Closest in spirit** | C/CompCert, one kernel image; layers = internal proof decomposition, not a shippable retargetable library; no wasm; no MCU |
+| Verified OS (tech twin) | Atmosphere (Verus, SOSP'25) | mars-research.github.io/projects/atmo | **Nearest twin (Rust+Verus)** | Single monolithic kernel; x86/MMU; single-prover; no wasm seam; not "parts you compose" |
+| | Tock / TickTock (Flux, SOSP'25) | ranjitjhala.github.io/static/sosp25-ticktock.pdf | Close (same M-class/RISC-V silicon, production) | Verifies *isolation* only, not primitive functional correctness; single prover; fixed kernel |
+| | seL4 / Microkit / LionsOS | sel4.systems | Brand threat | C kernel; isolates *unverified* PDs; re-verify per arch; no wasm |
+| Embedded Rust async | Embassy | github.com/embassy-rs/embassy | **Closest (executor template)** | kiln-async is "Embassy-inspired"; Embassy more mature/portable; no proofs, no WCET |
+| | embedded-hal-async | github.com/rust-embedded/embedded-hal | gale *adopts* it | Community standard; the unverified driver seam gale inherits |
+| | RTIC | rtic.rs | Close (bounded-by-construction) | SRP/type-based, not machine-checked; no WCET |
+| | Hubris (Oxide) | hubris.oxide.computer | Close (attestable image, tiny TCB) | Synchronous IPC; isolation via MPU, not proofs |
+| Commercial cert RTOS | SAFERTOS / VxWorks Cert / QNX / INTEGRITY-178 | highintegritysystems.com | Owns the value prop ("kernel + evidence pack") | Process/MC-DC test evidence, not machine-checked proof; C; not composable |
+| Open-source safety | Zephyr Safety | zephyrproject.org | **Co-opetition / drop-in host** | Process-evidence cert; gale must prove machine-checked adds value the Zephyr safety case lacks |
+| Drone/market pull | Auterion PX4 Pro / Dronecode | auterion.com | GTM wedge + threat | DO-178 process evidence; no formally-verified primitives |
+| Standards/academia (HAL seam) | Wasm-IO (EMSOFT'25, FAU/Dortmund) | dl.acm.org/doi/10.1145/3760387 | **Closest on the wasm/native seam** | Runtime-based; no machine-checked proofs; driver-containerization, not OS kit |
+| wasm formal semantics | WasmCert-Coq/Isabelle | conrad-watt.github.io/papers/watt2021.pdf | Closest on verification axis | Verifies the *language/interpreter*, not gale's components; runs interpreted |
+| Verified compilation | CompCert / RustCompCert (2026) | trustworthy.systems/projects/OLD/camkes | Flank synth will need | C/Rust-native; no wasm-as-boundary; no component-OS kit |
+
+## 3. gale's genuine novelty (the unoccupied intersection)
+
+The defensible white space is the **conjunction**, and only the conjunction. Precisely:
+
+1. **A library of *independently* verified, reusable, retargetable kernel primitives** — versus everyone shipping *one* verified kernel (seL4, CertiKOS, Atmosphere) or merely *isolating unverified parts* (seL4 Microkit PDs, Tock capsules). Closest on compositionality is CertiKOS/DeepSpec (flint.cs.yale.edu/certikos), but its layers are an internal proof decomposition compiled to one C image, not a shippable cross-target component library.
+
+2. **wasm as the verification *and* portability boundary, then fused away.** The wasm-on-MCU field (aWsm, WAMR, AkiraOS, Wasm-IO) uses wasm as a *runtime sandbox*; gale uses it as a fuse-and-discard build IR. Closest mechanically is aWsm (github.com/gwsystems/aWsm — wasm→LLVM-LTO→Cortex-M object, no interpreter), but it is C-based SFI sandboxing with zero proofs and no kernel library.
+
+3. **Component fusion (meld) + cross-component inlining (loom) + AOT-to-firmware (synth) as one pipeline.** wac fuses but doesn't compile; wasmtime/WAMR compile but keep a host runtime; w2c2 compiles-to-native-no-runtime but does per-module C with no component semantics. **No one does fusion + inlining + AOT-to-bare-metal together** — let alone carrying machine-checked proofs through the fusion.
+
+4. **Multi-backend simultaneous proof** (Verus/SMT + Rocq + Lean + Kani/BMC) of the *same* primitive code, at the *component* level. Every neighbor is single-prover (Tock=Flux, Atmosphere=Verus, seL4=Isabelle; WasmCert verifies only the language). This redundancy is genuinely unmatched in the surveyed set.
+
+5. **Dual-mode delivery** — drop-in C-primitive replacement (Zephyr) *and* build-your-own bespoke OS (gust, 8KB RAM, Cortex-M3) with a fuel-bounded-WCET async executor and ~4-function native TCB — plus **same-wasm retarget across M7/M4/M3/RISC-V by re-AOT + TCB swap**, versus seL4/CertiKOS re-verifying per architecture.
+
+**Claims to kill or soften (findings do not support them):**
+- ❌ "First to verify a Rust kernel on M-class silicon" — **false**; TickTock/Tock (SOSP'25) is published and in production (~10M devices).
+- ❌ "First to prove a Rust microkernel functionally correct with Verus" — **false**; Atmosphere (SOSP'25).
+- ❌ "Novel: wasm AOT'd to bare-metal Cortex-M" — **false**; aWsm, WAMR-AOT, w2c2, AkiraOS. Only the *fuse-it-entirely-away intent* + proofs are gale's.
+- ❌ "Novel: static composition of wasm components" — **false**; wac and wasm-tools compose are mature.
+- ❌ "Novel: logic-in-wasm / timing-DMA-in-thin-native-seam" — **overlapped**; Wasm-IO (EMSOFT'25) independently drew the same seam with temporal+spatial isolation.
+- ❌ "Novel: verified wasm" — **false**; WasmCert, VeriWasm, Veri-ISLE. gale's edge is verifying *kernel-primitive invariants*, not language/sandbox safety.
+- ⚠️ "Proof-carrying AOT fusion (synth)" — **unverified / partly roadmap.** Per project memory synth#167 (arm backend) was emitting non-linkable placeholders; this is the most differentiated *and* least externally-validated link. State it as roadmap, not shipped.
+- ⚠️ gale "closes the driver-verification gap" — **false.** The embedded-hal-async timing/DMA code is exactly the unverified part living in gale's TCB. gale *relocates and names* the gap (declared ~4-fn TCB); it does not eliminate it.
+
+## 4. Threats / where gale is NOT unique
+
+- **aWsm/eWASM convergence (fastest structural threat).** GWU already ships the codegen mechanic on Cortex-M *and* runs an OS group (Composite). Authoring primitives in wasm + adding proofs would close most of the moat. (github.com/gwsystems/aWsm)
+- **Bytecode Alliance convergence.** If BCA wires `wac` fusion into a Cranelift/LLVM no-runtime bare-metal backend (a plausible WAMR+wac merge), the structural moat collapses to *just the formal-verification layer*. WASI 0.3 async (Feb 2026) + the WAMR Embedded SIG push in this direction.
+- **Verus/Flux research front is crowded and well-resourced.** If Atmosphere or the Tock/TickTock teams reframe as a "verified primitive library," the technology overlap is large — they have the provers and the silicon already.
+- **Process-evidence certification "good enough."** SAFERTOS/VxWorks Cert/QNX/INTEGRITY-178 own the "kernel + evidence pack" market; Zephyr is bringing it open-source and free. If customers accept process evidence, gale's proof premium must be justified by *cost* (auto-generated cert evidence), not just rigor.
+- **The build-your-own idea is not gale's.** Mewz (unikernel fuse-to-native), R3-OS (assemble RTOS from primitive crates), Embassy/Ariel (async BYO) all exist. gale's delta is MCU bare-metal + proofs, not the BYO framing itself.
+- **The async executor is a reimplementation.** Embassy already nails no_std/no_alloc/single-stack/interrupt-sleep across many MCU families, and is arguably more mature than kiln-async today. Per-ingredient novelty here is low; the only defensible delta is *machine-checked + fuel-bounded-WCET + wasm-verifiable*.
+- **Could "WAMR-AOT + a verified kernel" close the gap?** Partially. WAMR-AOT gives production codegen; a verified kernel (Atmosphere/Tock) gives proofs. But the combination would still (a) keep WAMR's ~50K on-device runtime (not a ~4-fn TCB), (b) treat wasm as app layer not kernel substrate, and (c) lack proof-carrying fusion. The architectural inversion (kernel-as-wasm, compiled away) is the part that *cannot* be assembled from existing parts without redoing gale's pipeline.
+
+## 5. Market pull & positioning
+
+**Who buys this**
+- **Drones / PX4 / Dronecode (clearest wedge):** PX4-on-NuttX is the de-facto open autopilot; Auterion's DO-178/254 PX4 Pro is the NDAA-compatible US-defense OEM standard — and *nobody there offers formally-verified primitives* (auterion.com). gale's pitch: drop verified flight-critical components (sem/mutex/msgq/scheduler) under PX4 and *reduce DO-178 verification evidence cost* while raising assurance.
+- **Automotive / industrial safety (ASIL D / SIL 3 / IEC 62304):** the incumbent buyers of SAFERTOS/VxWorks Cert/QNX. gale competes on machine-checked-vs-process-evidence and on the auto-generated evidence pack.
+- **BCA / wasm-component ecosystem:** the component-model community is cloud-focused; gale is the embedded/verified outlier. Positioning here is "the verified embedded member of the component-model family," potentially via the WAMR Embedded SIG.
+- **Root-of-trust / secure elements:** Tock's existing footprint (Google/HP/WD, ~10M devices) shows real demand for verified Rust at the MCU root of trust — a natural target for verified primitives.
+
+**White space**
+The unserved buyer is the safety customer who wants **machine-checked correctness AND a build-your-own minimal OS AND cross-target retarget without per-arch re-verification AND lower cert-evidence cost** — none of the incumbents offer all four. gale's gust (8KB RAM, Cortex-M3, ~4-fn TCB) demonstrates the build-your-own end credibly.
+
+**README / pitch framing (recommended)**
+> "A library of formally-verified OS kernel primitives, authored in Rust→wasm, proven across Verus + Rocq + Lean + Kani, then statically fused and compiled *away* to bare-metal native with a ~4-function trusted base. Build a bespoke OS (gust) or drop verified primitives into Zephyr. The same proven wasm retargets across Cortex-M7/M4/M3 and RISC-V."
+
+Lead with the *inversion* ("we author the kernel in wasm and compile it away — nobody else does"), not with "verified wasm" (prior art) or "wasm on MCU" (crowded). Be explicit that the TCB is *named and tiny*, not zero. Do **not** claim first-verified-Rust-kernel or novel-AOT.
+
+## 6. Research gaps to claim (publishable, gale-led)
+
+1. **Proof-carrying AOT fusion to bare metal.** No one carries machine-checked component proofs *through* fuse+inline+AOT into a firmware image. CompCert/RustCompCert/Veri-ISLE cover adjacent compiler-correctness flanks but not wasm-component-fusion-to-MCU. This is gale's flagship open problem — *and* its biggest risk (synth#167 status: unverified/blocked per memory). Owning the proof that meld/loom/synth preserve primitive invariants would be a first.
+2. **Native-substrate WCET for a fuel-bounded async executor.** None of Embassy/RTIC/Tock/Hubris give a static execution-time bound; WCET in the field is an external-tool problem (LDRA/AbsInt) over compiled binaries. A *fuel-bounded WCET model that is a property of the executor* and survives AOT to native is unoccupied.
+3. **IRQ→waker correctness proof.** The interrupt→async-waker path is the trust seam between the verified wasm logic and the native HAL. Proving the IRQ-to-waker handoff (the gust rigor gap) is novel against Tock's MPU/IRQ-context-switch isolation proofs, which establish *isolation*, not *functional waker correctness*.
+4. **Compiler-TCB trust quantification.** What exactly must be trusted in synth, and how small can it be made (the ~4-function TCB claim)? A precise, mechanized statement of the residual TCB across an AOT-fuse pipeline is a contribution in its own right.
+5. **Multi-prover intersection methodology.** Writing primitives to the *intersection* of Verus + Rocq + Lean + Kani restrictions (no trait objects/closures/async in verified code) is itself a methodological result — what does redundant multi-backend proof buy over single-prover, and at what authoring cost? No surveyed project does this.
+6. **Retarget-without-re-verification.** Formalizing why the *same* verified wasm + a swapped TCB preserves correctness across M7/M4/M3/RISC-V — versus seL4/CertiKOS per-arch re-verification — is a portability-of-proof claim worth publishing.
+
+## 7. Recommendations (ranked)
+
+1. **Land and externally validate the proof-carrying synth pipeline (meld→loom→synth) end-to-end on gust.** This is the single load-bearing, least-validated claim (synth#167). Until a verified primitive demonstrably fuses+inlines+AOTs into a linkable Cortex-M image with proofs intact, the central moat is roadmap, not product. Highest priority, technical.
+2. **Benchmark codegen against aWsm and LLVM-LTO publicly.** aWsm reports ~40% MCU overhead; gale's own acceptable milestone is 10–20%. A head-to-head (size, overhead, TCB LOC) turns the "we beat the status quo" thesis into evidence and pre-empts the "aWsm already does this" rebuttal. Technical + positioning.
+3. **Reframe the pitch around the inversion + named TCB, and retire the overclaims** (first-verified-kernel, novel-AOT, novel-verified-wasm, closes-driver-gap). Ship a README that leads with "author the kernel in wasm, compile it away, ~4-function TCB, multi-prover." Cheap, high-leverage, positioning.
+4. **Pick the PX4/Dronecode wedge and produce one concrete artifact** — a verified primitive (e.g., msgq or scheduler) dropped under PX4 with a cert-evidence-cost story for DO-178. The drone market has the clearest pull and *zero* formally-verified incumbents. Positioning + technical.
+5. **Position against Zephyr safety as "machine-checked supplement," not replacement.** Frame gale's mode-1 drop-in as *adding* what the Zephyr process-evidence safety case structurally lacks (machine-checked functional correctness of the primitives), ideally with auto-generated evidence that *lowers* total cert cost. This directly neutralizes the biggest market threat. Positioning.
+6. **Publish the WCET + IRQ→waker + compiler-TCB results as the research flagship** (gaps 1–4 above), and engage the WAMR Embedded SIG / component-model community to establish gale as the "verified embedded" branch before BCA converges on the same architecture independently. Research + ecosystem defense.
+
+—
+Note: novelty claims are grounded in the supplied findings (confidence med-high across dimensions); all rest partly on absence-of-evidence for stealth/proprietary/non-English efforts, so "no competitor occupies the intersection" should be stated as *unverified-absent*, not proven-absent. The synth proof-carrying-fusion claim is **unverified** pending #2/#1 above.

--- a/docs/wasm-frontier-research.md
+++ b/docs/wasm-frontier-research.md
@@ -1,0 +1,143 @@
+---
+id: DOC-WASM-FRONTIER
+title: "What people are doing with wasm, and where gale fits (frontier sweep, 2026-06-20)"
+type: documentation
+status: proposed
+tags: [byo-os, gale74, wasm-frontier, market-research, wasm-r3, cra, wohl]
+links:
+  - type: related-to
+    target: FIND-BYOOS-002
+  - type: related-to
+    target: FIND-BYOOS-003
+  - type: related-to
+    target: DOC-BYOOS-MARKET
+---
+
+> **Source:** 8-dimension parallel research workflow (9 agents, 103 web lookups), 2026-06-20.
+> **Maintainer corrections (do not trust the report's stale memory references):**
+> 1. The report repeatedly cites **`synth#167`** as blocking the dissolved-native artifact.
+>    That is OUTDATED. The gust scout has PROVEN hot-path dissolution: `gust_poll` →
+>    **812 B of linkable Cortex-M3** (re-targets to RISC-V from one wasm). The real open
+>    links are **synth#382 (FIXED in v0.11.50)** and **synth#383 (`.bss` sizing, OPEN)**.
+>    So recommendation #1 ("unblock + bench the dissolved artifact") is closer than the
+>    report implies — the codegen works; the gaps are the 8 KB `.bss` link (#383) and the
+>    comparative bench (tasks #21–#22).
+> 2. **Biggest honest takeaways to act on:** (a) the import-tape **record-replay
+>    mechanism is prior art** — Wasm-R3 (OOPSLA 2024); ADOPT it and lead the pitch with
+>    *divergence-localization* (verification-cut = replay-cut), not "novel record-replay";
+>    (b) **"dissolve the runtime" is prior art** (wasm2c in Firefox, w2c2) — gale competes
+>    with native/LLVM-LTO and must *beat* Cranelift-AOT, not just runtimes; (c) **EU CRA**
+>    (signed/attested OTA mandatory by Dec 2027) + the **10–50× interpreted-wasm energy
+>    tax** are real tailwinds for OTA-of-verified-dissolved-wasm (wohl).
+
+# What People Are Doing with Wasm, and Where gale Fits
+
+*Frontier report — 2026-06-13. Grounded entirely in the supplied findings; URLs cited inline; thin evidence marked "unverified".*
+
+---
+
+## 1. The wasm frontier in one page
+
+- **Beyond-the-browser is the default, not the novelty.** Bytecode Alliance's 2025 survey: 67% of wasm devs work outside the browser. "Same .wasm everywhere" (browser/server/edge/embedded) is now an industry design assumption via WASI 0.2 + Component Model — portability differentiates nothing anymore ([thenewstack.io](https://thenewstack.io/4-big-developments-in-webassembly/)).
+- **The Component Model crossed into production-mainstream.** WASI 0.2 stabilized the CM+WIT interop contract; WASI 0.3.0 ratified (preview Aug 2025, landed Feb 2026) adds native async (`stream<T>`/`future<T>`), closing the last server gap; CM 1.0 is the explicit next target ([Road to CM 1.0](https://bytecodealliance.org/articles/the-road-to-component-model-1-0)).
+- **"AOT and dissolve the runtime" went mainstream.** Wasm 3.0 became a W3C standard (Sep 2025) — SIMD/relaxed-SIMD/tail-calls/memory64/WasmGC ([webassembly.org](https://webassembly.org/news/2025-09-17-wasm-3.0/)). wasm2c ships in **production** in Firefox via RLBox; w2c2+cc beats Wasmtime on Ed25519 (73.5s vs 125s, ~150KB binary) ([00f.net](https://00f.net/2023/12/11/webassembly-compilation-to-c/)). "The best wasm runtime may be no runtime at all" is a named, established thesis — **gale's core dissolve move is prior art in kind.**
+- **Record-replay at the wasm import boundary is published, open-source technique.** Wasm-R3 (OOPSLA 2024) records the host-import trace, reduces it ~99.5%, emits a standalone replay module runnable on any engine ([github](https://github.com/sola-st/wasm-r3)). CMU is building bidirectional wasm time-travel debugging on Wasmtime (Oct 2025) ([CMU](https://www.cs.cmu.edu/~wasm/wasm-research-day-2025b.html)). **gale's boundary-tape mechanism is no longer novel.**
+- **Energy reality check landed hard.** Dec-2025 benchmark (arXiv 2512.00035) and treVM (DCOSS-IoT 2026): interpreted wasm is 10–50x native energy, 130–480KB RAM — the field openly concedes native/AOT is needed for battery ([arXiv 2512.00035](https://arxiv.org/html/2512.00035v1)).
+- **Verification stratified, but app-correctness end-to-end is unoccupied.** Cranelift lowering is now SMT-verified rule-by-rule (Crocus/Veri-ISLE, ASPLOS 2024); Iris-Wasm formalizes the import-seam-as-cut (PLDI 2023); RichWasm carries type proofs in custom sections (PLDI 2024). Almost nobody carries **functional-correctness** proofs from source through compilation to native ([Veri-ISLE](https://cfallin.org/pubs/asplos2024_veri_isle.pdf), [Iris-Wasm](https://dl.acm.org/doi/abs/10.1145/3591265)).
+- **Market is consolidating, not gold-rushing.** Akamai acquired Fermyon (Dec 2025); pure-play wasm cloud is hard to monetize standalone. New energy went to AI-agent sandboxing, not verified-embedded ([siliconangle](https://siliconangle.com/2025/12/01/akamai-acquires-webassembly-function-service-startup-fermyon/)).
+- **Home automation is hitting battery/cost walls with a wasm-on-MCU answer already shipping.** Espressif ships esp-wasmachine/esp-wdf (WAMR-based, remote install) and split system/app firmware via ESP LowCode Matter — the closest commercial pattern to wohl, but runtime-on-device, unverified ([esp-wdf](https://github.com/espressif/esp-wdf)). EU CRA (full compliance Dec 2027) turns signed/attestable OTA into a market-access requirement ([anchore](https://anchore.com/sbom/eu-cra/)).
+
+---
+
+## 2. Map
+
+| Dimension | Key players (url) | What's hot | gale adjacency | Overlap / threat |
+|---|---|---|---|---|
+| **Debug / dev-loop** | Wasm-R3 ([github](https://github.com/sola-st/wasm-r3)); CMU TTD ([cmu](https://www.cs.cmu.edu/~wasm/wasm-research-day-2025b.html)); Chrome DevTools DWARF ([chrome](https://developer.chrome.com/docs/devtools/wasm)); LLDB-for-wasm ([fosdem '26](https://fosdem.org/2026/events/attachments/87ZLQV-wasm-debugging-lldb/slides/267097/webassemb_alaohmr.pdf)) | Record-replay at import boundary; bidirectional time-travel; DWARF source-level step in-browser | Verification cut **is** the replay cut; record on MCU, replay in host/browser; ship DWARF for free in-browser stepping | **High.** Boundary-tape no longer novel; if CMU/Wasmtime add an embedded record backend, generic loop becomes commodity |
+| **Embedded / IoT** | WAMR ([github](https://github.com/bytecodealliance/wasm-micro-runtime)); wasm3; Atym ([atym.io](https://www.atym.io/post/a-look-into-atym-s-containerization-technology-leveraging-webassembly)); treVM ([arXiv](https://arxiv.org/html/2604.27570)); arXiv 2512.00035 | Component-as-firmware over fleets; energy reality check; OTA wasm plugins/drivers | Dissolve-to-native is the energy-correct answer; same component browser/host/MCU | **High.** WAMR is the de-facto baseline; Atym owns commercial narrative; AOT is becoming table-stakes |
+| **Component Model / WASI** | Bytecode Alliance ([CM 1.0](https://bytecodealliance.org/articles/the-road-to-component-model-1-0)); Wasmtime; wac ([github](https://github.com/bytecodealliance/wac)); Fermyon; wasmCloud | WASI 0.3 native async; CM 1.0 lazy ABI; build-time composition (wac); nanoprocesses (unshipped) | Adopt WIT as official seam; map host event loop to MCU IRQ/DMA; deliver nanoprocess isolation on 8KB | **Medium-high.** Composition is mainstream; if a verifying AOT bolts onto Wasmtime's CM pipeline, moat narrows to proofs |
+| **Novel uses** | Shopify Functions ([shopify](https://shopify.dev/docs/apps/build/functions)); Zed ([zed](https://zed.dev/blog/zed-decoded-extensions)); SingleStore; proxy-wasm/OPA; Arbitrum Stylus; AkiraOS ([hackster](https://www.hackster.io/Artur_R0K3R/akiraos-wasm-runtime-for-microcontrollers-dcc59e)) | Wasm as plugin/UDF/policy/contract ABI; narrow typed host↔guest seam everywhere | Verified components as drop-in proven UDFs/policies for safety-critical edge | **Medium.** The seam is commoditized; novelty is what gale does with it, not the seam |
+| **AOT / perf** | Cranelift/Winch ([cranelift.dev](https://cranelift.dev/)); wasm2c+RLBox ([github](https://github.com/PLSysSec/rlbox_wasm2c_sandbox)); w2c2; WARP ([github](https://github.com/wasm-ecosystem/wasm-compiler)); Wasm 3.0 | "No runtime at all" shipping; bare-metal AOT a category; Cranelift within ~2% of TurboFan | Same spectrum, fully-dissolving + proof-carrying end; lower relaxed-SIMD/tail-calls on MCU | **High.** Dissolve is mainstream; gale competes with **native/LLVM-LTO**, not just runtimes; perf bar is near-native |
+| **Verification / security** | VeriWasm; Crocus/Veri-ISLE ([pdf](https://cfallin.org/pubs/asplos2024_veri_isle.pdf)); WasmCert; Iris-Wasm ([acm](https://dl.acm.org/doi/abs/10.1145/3591265)); RichWasm ([arXiv](https://arxiv.org/pdf/2401.08287)); Enarx | Verification-in-compiler; import-seam robust-safety theory; proof-carrying custom sections | Iris-Wasm backs the seam claim; adopt RichWasm proof-carriage; VeriWasm-class post-dissolve gate | **Medium.** Each piece has an owner; gale's intersection (app-correctness + dissolve to runtime-free MCU) is unoccupied |
+| **Market momentum** | Fermyon→Akamai ([siliconangle](https://siliconangle.com/2025/12/01/akamai-acquires-webassembly-function-service-startup-fermyon/)); wasmCloud/CNCF; Extism; SpecTec ([webassembly.org](https://webassembly.org/news/2025-03-27-spectec/)) | Consolidation; AI-agent sandboxing; WASI async; machine-checked spec | Ride the standard; co-opt "prove the kernel, don't just sandbox" vocabulary | **Medium.** Portability is table-stakes; verified-embedded is not a recognized buyer category (evangelism burden) |
+| **Home-automation MCU** | Espressif esp-wdf/ESP LowCode ([esp-wdf](https://github.com/espressif/esp-wdf)); ESP32-C6/H2; nRF54L15 ([nordic](https://www.nordicsemi.com/Products/nRF54L15)); SiWx917; seL4/LionsOS+Verus ([sel4](https://sel4.systems/Summit/2025/abstracts2025.html)); EU CRA | Split firmware mainstream; wasm-as-app-unit shipping; battery pain (Matter-over-Thread ~8mo); CRA forcing function | OTA-of-verified-wasm dissolved-native; import seam = vendor-TCB/app contract; replay field battery bugs | **High.** esp-wdf is free/vendor-backed on volume silicon; seL4 owns "verified embedded" mindshare |
+
+---
+
+## 3. Adjacencies gale should exploit (ranked)
+
+**1. Adopt the Wasm-R3 recorder design wholesale; add the verification twist.** Wasm-R3 already records import-boundary interaction (host calls + linear-memory/table deltas) and reduces traces ~99.5% ([github](https://github.com/sola-st/wasm-r3)). gale lifts the recorder but feeds the tape into the **same verified component** instantiated in wasmtime/kiln/browser — not a baked standalone module. The delta: because gale components are proven, **replay divergence is diagnostic gold** — identical import tape diverging device-vs-host means the bug is provably *not* in the verified logic, localizing it to TCB-or-HW. That localization guarantee is what Wasm-R3 and CMU-TTD cannot make. Tie directly to the silicon-anchor capture matrix already scaffolded in `benches/engine_control/silicon` (DWT counters, events.csv) so the import tape is a superset of a debug trace.
+
+**2. Make WIT + the Component Model the official public seam, not an internal convention.** Author kernel components against real WIT worlds so the *same verified artifact* runs in wac/wasmCloud compositions, loads in Wasmtime/WAMR for host test, and dissolves to native via meld/loom/synth. Differentiator becomes "the only toolchain that takes a *standard* component all the way to runtime-free bare metal." Critically, this de-risks the interop gale is counting on — if the TCB import seam diverges from WASI/CM conventions, gale **loses** the same-component-everywhere property it leans on. Ride the standard ([CM 1.0](https://bytecodealliance.org/articles/the-road-to-component-model-1-0)).
+
+**3. Ship DWARF with the pre-dissolve module for a free in-browser debugger.** Chrome DevTools DWARF ([chrome](https://developer.chrome.com/docs/devtools/wasm)) and the LLDB-for-wasm push ([fosdem '26](https://fosdem.org/2026/events/attachments/87ZLQV-wasm-debugging-lldb/slides/267097/webassemb_alaohmr.pdf)) give a ready-made UI seam: a replayed tape becomes steppable at source level in-browser with **zero custom debugger**. Pair with CMU's bidirectional-replay idea for reverse step-through of a captured wohl/PX4 field bug.
+
+**4. Adopt Wizer for deterministic replay start-state.** Wizer ([github](https://github.com/bytecodealliance/wizer)) pre-init snapshots (now CM-aware) give the replay a deterministic, reproducible instantiation point — the start-of-tape state — for free. Also a legitimate boot-time win for wohl/gust cold start.
+
+**5. Borrow Wasm 3.0 features as a richer input ISA.** Relaxed-SIMD and guaranteed tail calls are now standard ([wasm 3.0](https://webassembly.org/news/2025-09-17-wasm-3.0/)); loom-inlining + synth-AOT can lower relaxed-SIMD to MCU DSP/SIMD lanes and use TCO to flatten state machines — exploitable harder by the "tiny = optimal regalloc" thesis than by a general JIT.
+
+**6. Map WASI 0.3 native async onto the bare-metal scheduler.** The host-owned single event loop (`stream<T>`/`future<T>`) is a clean match for an MCU's interrupt/DMA model. Exposing verified async drivers through standard async WIT is **genuinely novel** — nobody runs CM async on bare metal.
+
+---
+
+## 4. Validation of the replay/dev-loop idea
+
+**Does record-on-HW / replay-in-host exist anywhere?** The *mechanism* exists and is published; the *exact gale loop* does not.
+
+- **Closest public art: Wasm-R3 (OOPSLA 2024)** ([github](https://github.com/sola-st/wasm-r3), [arXiv 2409.00708](https://arxiv.org/abs/2409.00708)). It does precisely "record at the import boundary, replay on a different engine," with the cross-runtime shape gale claims (record in any browser, replay anywhere). **But** its stated purpose is benchmark extraction, and its artifact is a self-contained module with host emulation baked in — *not* a tape re-fed through a live verification seam. RR-Reduce (ASE 2025) extends it ([pdf](https://software-lab.org/publications/ase2025_RR-Reduce.pdf)). A second, independent record/replay paper (arXiv 2506.07834, June 2025) records a function's boundary interactions to reproduce/reduce bugs ([arXiv](https://arxiv.org/abs/2506.07834)).
+- **Debugging-first, single-runtime: CMU TTD** ([cmu](https://www.cs.cmu.edu/~wasm/wasm-research-day-2025b.html)) — low-overhead bidirectional record/replay, **Wasmtime-only, no device→host story.**
+- **In the reference runtime: Wasmtime** is independently building record/replay + WasmDebugging/SourceDebugging WIT interfaces (record-on-Cranelift/replay-on-Winch) ([wasmtime](https://docs.wasmtime.dev/examples-pre-compiling-wasm.html)) — *emerging, not confirmed GA (unverified as shipped)*.
+
+**gale's genuine delta (survives the prior art):**
+1. **Record on real embedded/MCU hardware.** Wasm-R3 records in browsers; CMU-TTD on host Wasmtime. Neither targets bare-metal dissolved-native. *No public instance of the exact HW-device-record → host/browser-replay-for-debugging loop was found in 2024–2026 sources (absence of evidence, not proof of absence — unverified).*
+2. **Verification-cut = replay-cut.** Divergence on an identical tape provably excludes the verified logic and localizes to TCB-or-HW. This is the load-bearing, unclaimed framing — backed theoretically by Iris-Wasm's robust-safety boundary ([acm](https://dl.acm.org/doi/abs/10.1145/3591265)).
+3. **Dissolved-native deployment where the replayed module and the device module are the same verified artifact** (provenance by construction through meld/loom/synth).
+
+**Verdict: do not kill — but stop pitching the mechanism as new.** The boundary-tape idea is anticipated. Lead with the proof (divergence localization) and the bare-metal record backend; those are unclaimed. If gale keeps marketing "record-replay across runtimes" as the innovation, reviewers will point at Wasm-R3 immediately.
+
+---
+
+## 5. Threats / convergence risk
+
+- **The generic loop becomes free commodity.** If CMU-TTD or Wasm-R3 adds an embedded recording backend, or Wasmtime's bidirectional record-replay lands as a first-class feature, gale's debug story collapses to "we also have proofs." This is the single sharpest convergence risk ([cmu](https://www.cs.cmu.edu/~wasm/wasm-research-day-2025b.html), [github](https://github.com/sola-st/wasm-r3)).
+- **A verifying AOT bolted onto Wasmtime's CM pipeline.** If CM 1.0's lazy ABI + nanoprocess shared-nothing linking land well and someone attaches a Crocus-style verifying AOT to Wasmtime's component pipeline, the "same verified component in browser/host/MCU + replay" story is largely deliverable on stock Wasmtime — minus the bare-metal dissolve. gale's moat then narrows to the proof tracks alone ([CM 1.0](https://bytecodealliance.org/articles/the-road-to-component-model-1-0), [Veri-ISLE](https://cfallin.org/pubs/asplos2024_veri_isle.pdf)).
+- **WAMR / AkiraOS / esp-wdf own embedded today.** Portable, sandboxed, OTA-updatable wasm on Cortex-M/Zephyr is in production with ~64KB runtimes and momentum ([WAMR](https://github.com/bytecodealliance/wasm-micro-runtime), [AkiraOS](https://www.hackster.io/Artur_R0K3R/akiraos-wasm-runtime-for-microcontrollers-dcc59e), [esp-wdf](https://github.com/espressif/esp-wdf)). "Wasm on MCU" reads as WAMR first. gale gets no novelty for it — only for verified + zero-runtime.
+- **AOT closes the perf gap.** WAMR-AOT ~50% native and shipping on ESP32; Cranelift within ~2% of TurboFan. gale's "optimal-because-tiny regalloc" must demonstrably **beat Cranelift-AOT**, not match LLVM — and **synth's ARM backend is currently blocked (synth#167, meld-dispatch placeholders, non-linkable .o)**, so gale cannot yet demonstrate the dissolved-native artifact that beats WAMR-AOT, which is the central claim ([per memory note; not re-verified in repo this session — unverified]).
+- **"No runtime" is established prior art.** wasm2c-in-Firefox and Frank Denis's thesis name gale's exact pitch ([00f.net](https://00f.net/2023/12/11/webassembly-compilation-to-c/)). The low-cost 80/20 (sandbox + native + tiny binary *without* formal verification) is a far lower adoption cost — if gale's proofs don't catch bugs wasm2c+sandbox would miss, verification is overhead, not moat.
+- **Hyperscaler / consolidation.** The Fermyon→Akamai exit shows pure-play wasm is hard to fund standalone; if a hyperscaler ships a verified edge component product, gale's window narrows ([siliconangle](https://siliconangle.com/2025/12/01/akamai-acquires-webassembly-function-service-startup-fermyon/)).
+- **seL4 owns "verified embedded" mindshare.** A decade of proof pedigree plus DARPA funding and Verus-on-seL4 (2025) ([sel4](https://sel4.systems/Summit/2025/abstracts2025.html)). gale's counter — seL4 is a runtime TCB on device, not the same artifact across browser/host/MCU, and not an OTA-wasm story — is nuanced and easy to lose in a soundbite.
+
+---
+
+## 6. wohl (home automation) read
+
+**Is verified + dissolved-wasm + OTA a real fit? Yes on technical alignment; unvalidated on market pull.**
+
+- **The market independently validated gale's two core moves.** (1) **Split firmware is mainstream** — Espressif ESP LowCode separates vendor "system firmware" (Matter + radios + OTA) from customer "application firmware," even pinning system to HP core / app to LP core on C6 ([esp blog](https://developer.espressif.com/blog/2025/02/introducing-esp-lowcode-matter/)). gale's verified-component + narrow import seam **is** that cut, but principled: the seam is verification boundary *and* OTA unit *and* replay cut. (2) **Wasm as the app unit is shipping** — esp-wasmachine/esp-wdf does remote wasm/AOT install over the wire ([esp-wdf](https://github.com/espressif/esp-wdf)). gale does the same shipping story but dissolves to native, claiming WAMR's portability/isolation **without** the ~20–25% runtime tax and RAM cost — decisive on coin-cell / gust-class 8KB budgets where sleep current and flash are the BOM.
+- **The battery pain is real and gale's dissolve is the right answer.** A correct Thread/Zigbee node should last 12–36 months on a coin cell at 2–10µA sleep, yet real Matter-over-Thread sensors reportedly need swaps in ~8 months; arXiv 2512.00035 quantifies interpreted wasm at 10–50x native energy ([arXiv 2512.00035](https://arxiv.org/html/2512.00035v1)). Dissolve-to-native sidesteps the runtime energy tax entirely — **but the numbers are asserted, not benched** (blocked on synth#167 / the open gust comparative bench, tasks #21–#22). Until that bench lands, this is a claim, not a proof.
+- **Regulation is a genuine tailwind.** EU CRA mandates machine-readable SBOMs, secure-by-design, vuln management, and secure OTA for all connected products (vuln reporting Sept 2026, full compliance Dec 2027, penalties to €15M/2.5% revenue) ([anchore](https://anchore.com/sbom/eu-cra/)). "Provably correct + attestable + signed OTA" shifts from nice-to-have to market-access requirement — directly favorable to OTA-of-verified-wasm with proof-carrying provenance.
+
+**Honest counterweights:**
+- **esp-wdf is the free, vendor-backed incumbent** on the volume-cost silicon, already doing OTA-style install. "Why not just use esp-wdf?" kills wohl unless gale shows the dissolved path beats WAMR-AOT on flash/RAM/energy *and* carries a proof. (It's still "Preview" — a window, but Espressif's distribution will close it.)
+- **Inversion risk on the safety pitch.** Split firmware means the part nobody trusts and everyone wants verified is the *vendor system firmware* (radio + Matter + OTA) — which gale treats as untrusted TCB and does **not** verify. gale only verifies the app side, the less safety-critical half. This needs a crisp answer.
+- **Demand is greenfield.** Matter/Thread/Zigbee 2025 coverage shows **zero** explicit wasm integration in home automation. Opportunity *and* unvalidated demand — there is no established buyer category or budget line for verified-embedded wasm; it must be evangelized.
+
+---
+
+## 7. Recommendations (ranked)
+
+**1. Unblock and bench synth#167 before any external positioning — this gates the central claim.** Every differentiator (energy, flash/RAM win, "beats WAMR-AOT," dissolved-artifact-as-replay-target) depends on a dissolved-native artifact that does not yet exist on ARM. Land the gust comparative bench (tasks #21–#22) producing head-to-head flash/RAM/sleep-current numbers vs WAMR-AOT. *Tied to: §5 perf-gap threat, §6 battery claim being asserted-not-benched.* Until this lands, the moat is rhetorical.
+
+**2. Reframe the dev-loop pitch: lead with divergence-localization, not record-replay.** Stop marketing the boundary-tape mechanism as novel (Wasm-R3 anticipated it). Build the recorder by lifting Wasm-R3's design, target the **MCU record backend** (the unclaimed part), and headline the proof-backed guarantee: identical-tape divergence localizes to TCB-or-HW, never the verified logic. *Tied to: §4 verdict, §3 adjacency #1.*
+
+**3. Commit to WIT/Component Model as the official seam.** Author components against real WIT worlds; accept `.wac` composition graphs as front-end input; adopt Wasmtime's replay-tape / WasmDebugging WIT interfaces if/when they ship so HW tapes replay in stock Wasmtime with zero bespoke glue. This both rides the rising standard and protects the same-component-everywhere property gale depends on. *Tied to: §2 CM threat, §3 adjacency #2.* **If gale ever ships an on-device interpreter it collapses into the WAMR category — never do this.**
+
+**4. Position wohl as "OTA-of-verified-wasm, CRA-grade," riding split firmware.** Map the import seam onto the established vendor-TCB / customer-app contract; ship signed, attested, proof-carrying components dissolved-native into A/B OTA slots. Use the CRA SBOM/secure-OTA mandate as the wedge into a category that has no incumbent. *Tied to: §6 split-firmware validation + CRA tailwind.* **Pre-empt the inversion risk** by being explicit that gale verifies app logic at the seam and treats the radio/Matter stack as declared TCB — and offer the replay loop as the field-debug tool for the TCB/HW side.
+
+**5. Claim the nanoprocess vision concretely where the mainstream can't reach.** Shared-nothing linking is the ecosystem's *unshipped* security promise. Deliver it: each verified component keeps its own linear memory + minimal capabilities, fused statically with proofs that isolation holds, on an 8KB-RAM Cortex-M3 (gust). That is a demonstrable thing the mainstream only aspires to. *Tied to: §2 nanoprocess gap, §1 verification-unoccupied finding.*
+
+**6. Sharpen the two-line distinction against the two incumbents that will be invoked.** Against WAMR/esp-wdf: "they keep a runtime + TCB on the device; gale dissolves to native with no runtime and a machine-checked TCB." Against seL4: "they verify a runtime microkernel on device; gale verifies the *component logic*, removes the runtime, and runs the *same artifact* in browser/host/MCU." Bake these into every pitch so gale is never miscategorized. *Tied to: §5 WAMR + seL4 threats.*
+
+---
+
+*Confidence: High on the landscape and on the three central findings — (a) import-boundary record / cross-engine replay is already published (Wasm-R3), (b) "no runtime" dissolve is established prior art (wasm2c/w2c2/Frank Denis), (c) no mainstream player ships verified + dissolved wasm on MCUs. Medium on whether stock Wasmtime+verified-Cranelift+TTD could subsume gale's non-dissolve story (research, not one shipped product). Findings on synth#167 status and gust energy numbers are drawn from memory notes, not re-verified in-repo this session — marked unverified.*


### PR DESCRIPTION
Constructs the architecture for **#74** (gale as composable OS components — a first-class build-your-own-OS mode, C-free Rust+wasm), generalising the gust proof. **Design, not code** — opens the concrete plan for discussion.

## What's here
- **`artifacts/byo_os.yaml`** (12 rivet artifacts): stakeholder → finding → system-req → 4 sw-reqs → 5 sw-arch-components. The finding (`FIND-BYOOS-001`) captures the reframe; the arch components are the layer cake (scaffold / kiln-async exec / embedded-hal-async seam + Embassy HAL / wasm verifiable logic / gale primitives).
- **`docs/byo-os-architecture.md`** (`DOC-BYOOS-ARCH`): the layer cake (mermaid), the key insight that **the verification boundary IS the wasm/native seam**, the RT1176 SVD enabler, and the open rigor inherited from gust.

## Answers to #74's three asks
1. **First-class BYO-OS mode? — Yes.** A construction crate = `plain/` primitives + kiln-async + a reusable boot/sched-init/`device_init` scaffold (gust factored into hooks).
2. **device_init / work / poll the right hooks? — `device_init` yes, `poll` yes, `work` no** (kiln-async *is* the executor; deferred work is a task). The driver framework is a thin new `embedded-hal-async` layer, not routed through `work`.
3. **Positioning "composable OS components, drop-in or BYO, C-free"? — Yes, and accurate** — both modes are proven (drop-in: 36 QEMU suites + wasm-dist; BYO: gust).

## Driver model
`embedded-hal-async` seam → Embassy-class native async HAL (DMA/IRQ-completion, IRQ→waker) → kiln-async executor; Kani-proven decode/voting stay wasm *above* the traits. Verify what's verifiable; trust battle-tested async-HAL for timing/DMA.

## Validation
`rivet validate` PASS (exit 0); the 5 new warnings are the expected "proposed req should be verified" notices (verification lands when the work does).

Cross-refs: #74, #65 (gust), #63 (host substrate epic); jess DD-006/DD-011/DD-012/DD-015/DD-017.

🤖 Generated with [Claude Code](https://claude.com/claude-code)