### PR TITLE
feat(demo): full verified-components kit in the browser (mutex + event)

### DIFF
--- a/benches/gust/browser/.gitignore
+++ b/benches/gust/browser/.gitignore
@@ -1,2 +1,3 @@
 /target
 /web/gust.wasm
+/Cargo.lock

--- a/benches/gust/browser/README.md
+++ b/benches/gust/browser/README.md
@@ -4,8 +4,7 @@
 that targets the Cortex-M3:
 
 1. **gale verified components** — the actual formally-verified decision functions
-   (`gale::sem::give_decide`/`take_decide`, `gale::msgq::put_decide`/`get_decide`),
-   proven with **Verus + Rocq + Lean + Kani**. Interactive semaphore + message-queue
+   (`gale::sem`, `gale::msgq`, `gale::mutex`, `gale::event` deciders), proven with **Verus + Rocq + Lean + Kani**. Interactive semaphore, message-queue, mutex and event
    panels: you drive `give/take` and `put/get`, the **verified decision**
    (INCREMENT/WAKE/SATURATED, STORE/WAKE_READER/PEND/FULL/EMPTY) is computed by the
    proven gale code, and the page applies it. This is the *same* logic that ships in
@@ -25,8 +24,8 @@ cd web && python3 -m http.server # open http://localhost:8000/
 ```
 
 ## What's gale vs what's not (the honest map)
-- **gale (verified):** `gale_sem_give/take`, `gale_msgq_put/get` → call the proven
-  `gale::sem` / `gale::msgq` deciders.
+- **gale (verified):** `gale_sem_give/take`, `gale_msgq_put/get`, `gale_mutex_lock/unlock`,
+  `gale_event_post/wait` → call the proven `gale::{sem,msgq,mutex,event}` deciders.
 - **kiln (executor):** `gust_boot/gust_poll` → kiln-async `Scheduler`.
 - **gust app (not verified):** `gust_mix` → the ~10-line fixed-point failsafe mixer.
 

--- a/benches/gust/browser/src/lib.rs
+++ b/benches/gust/browser/src/lib.rs
@@ -105,3 +105,36 @@ pub extern "C" fn gale_msgq_get(
 ) -> i32 {
     gale::msgq::get_decide(read_idx, used, max, has_waiter != 0, is_no_wait != 0).decision as i32
 }
+
+/// gale::mutex::lock_decide — ACQUIRE=0 / REENTRANT=1 / PEND=2 / BUSY=3 / OVERFLOW=4
+/// (Verus-proven: ownership M3–M5, reentrant count M4, no overflow M10).
+#[no_mangle]
+pub extern "C" fn gale_mutex_lock(
+    lock_count: u32, owner_is_null: u32, owner_is_current: u32, is_no_wait: u32,
+) -> i32 {
+    gale::mutex::lock_decide(lock_count, owner_is_null != 0, owner_is_current != 0, is_no_wait != 0) as i32
+}
+
+/// gale::mutex::unlock_decide — NOT_LOCKED=0 / NOT_OWNER=1 / RELEASED=2 / FULLY_UNLOCKED=3
+/// (Verus-proven: -EINVAL M6a, -EPERM M6b, reentrant M7, no underflow M10).
+#[no_mangle]
+pub extern "C" fn gale_mutex_unlock(
+    lock_count: u32, owner_is_null: u32, owner_is_current: u32,
+) -> i32 {
+    gale::mutex::unlock_decide(lock_count, owner_is_null != 0, owner_is_current != 0) as i32
+}
+
+/// gale::event::post_decide — returns the new event bitmask `(current & !mask) | (new & mask)`
+/// (Verus-proven bitmask algebra).
+#[no_mangle]
+pub extern "C" fn gale_event_post(current_events: u32, new_events: u32, mask: u32) -> u32 {
+    gale::event::post_decide(current_events, new_events, mask)
+}
+
+/// gale::event::wait_decide — MATCHED=0 / PEND=1 / TIMEOUT=2 (wait_type: 0=ANY, 1=ALL).
+#[no_mangle]
+pub extern "C" fn gale_event_wait(
+    current_events: u32, desired: u32, wait_type: u32, is_no_wait: u32,
+) -> i32 {
+    gale::event::wait_decide(current_events, desired, wait_type as u8, is_no_wait != 0).decision as i32
+}

--- a/benches/gust/browser/web/index.html
+++ b/benches/gust/browser/web/index.html
@@ -67,6 +67,40 @@
         <span class="decide" id="mq_decide">—</span>
       </div>
     </div>
+    <!-- mutex -->
+    <div style="margin-top:16px">
+      <div class="k">k_mutex (<code>gale::mutex</code>) — ownership + reentrancy</div>
+      <div class="row">
+        <div>owner <span class="v gale-fg" id="mx_owner">—</span></div>
+        <div>lock_count <span class="v" id="mx_lc">0</span></div>
+        <button class="g" id="mx_a_lock">A lock()</button>
+        <button class="g" id="mx_b_lock">B lock()</button>
+        <button class="g" id="mx_a_unlock">A unlock()</button>
+        <button class="g" id="mx_b_unlock">B unlock()</button>
+        <label><input type="checkbox" id="mx_nowait" checked> no-wait</label>
+        <span class="decide" id="mx_decide">—</span>
+      </div>
+    </div>
+
+    <!-- event -->
+    <div style="margin-top:16px">
+      <div class="k">k_event (<code>gale::event</code>) — bitmask post / wait</div>
+      <div class="slots" id="ev_bits"></div>
+      <div class="row">
+        <button class="g" id="ev_p0">post b0</button>
+        <button class="g" id="ev_p1">post b1</button>
+        <button class="g" id="ev_p2">post b2</button>
+        <button class="g" id="ev_p3">post b3</button>
+        <button class="g" id="ev_clear">clear</button>
+      </div>
+      <div class="row">
+        <label>wait for <input type="text" id="ev_des" value="0101" size="5" style="width:54px;background:#0a0e12;color:var(--fg);border:1px solid #2a3a4a;border-radius:5px"></label>
+        <label><input type="checkbox" id="ev_all" checked> ALL (vs ANY)</label>
+        <button class="g" id="ev_wait">wait()</button>
+        <span class="decide" id="ev_decide">—</span>
+      </div>
+    </div>
+
     <pre class="log" id="log"></pre>
   </div>
 
@@ -155,6 +189,49 @@
     renderMq();
   };
   renderMq();
+
+  // ---- gale::mutex (verified) ----
+  let mxOwner=null, mxLc=0; const LOCK=['ACQUIRE','REENTRANT','PEND','BUSY','OVERFLOW'], UNLOCK=['NOT_LOCKED','NOT_OWNER','RELEASED','FULLY_UNLOCKED'];
+  function renderMx(){ $('mx_owner').textContent = mxOwner||'—'; $('mx_lc').textContent = mxLc; }
+  function mxLock(th){
+    const nw=$('mx_nowait').checked?1:0;
+    const d=g.gale_mutex_lock(mxLc, mxOwner===null?1:0, mxOwner===th?1:0, nw);   // VERIFIED
+    if(d===0){ mxOwner=th; mxLc=1; setDec($('mx_decide'),th+': ACQUIRE','ok'); }
+    else if(d===1){ mxLc++; setDec($('mx_decide'),th+': REENTRANT','ok'); }
+    else if(d===2){ setDec($('mx_decide'),th+': PEND (owned by '+mxOwner+')','warn'); }
+    else if(d===3){ setDec($('mx_decide'),th+': BUSY (-EBUSY)','bad'); }
+    else { setDec($('mx_decide'),'OVERFLOW','bad'); }
+    log(`gale::mutex::lock_decide(lc=${mxLc}, null=${mxOwner===null}, cur=${mxOwner===th}, no_wait=${!!nw}) → ${LOCK[d]}`);
+    renderMx();
+  }
+  function mxUnlock(th){
+    const d=g.gale_mutex_unlock(mxLc, mxOwner===null?1:0, mxOwner===th?1:0);      // VERIFIED
+    if(d===0){ setDec($('mx_decide'),th+': NOT_LOCKED (-EINVAL)','bad'); }
+    else if(d===1){ setDec($('mx_decide'),th+': NOT_OWNER (-EPERM)','bad'); }
+    else if(d===2){ mxLc--; setDec($('mx_decide'),th+': RELEASED','ok'); }
+    else { mxOwner=null; mxLc=0; setDec($('mx_decide'),th+': FULLY_UNLOCKED','wake'); }
+    log(`gale::mutex::unlock_decide(lc=${mxLc}, null=${mxOwner===null}, cur=${mxOwner===th}) → ${UNLOCK[d]}`);
+    renderMx();
+  }
+  $('mx_a_lock').onclick=()=>mxLock('A'); $('mx_b_lock').onclick=()=>mxLock('B');
+  $('mx_a_unlock').onclick=()=>mxUnlock('A'); $('mx_b_unlock').onclick=()=>mxUnlock('B');
+  renderMx();
+
+  // ---- gale::event (verified) ----
+  let ev=0; const WAIT=['MATCHED','PEND','TIMEOUT'];
+  function renderEv(){ const s=$('ev_bits'); s.innerHTML='';
+    for(let i=3;i>=0;i--){ const d=document.createElement('div'); d.className='slot'+((ev>>i&1)?' full':''); d.textContent=(ev>>i&1)?'1':'0'; s.appendChild(d);} }
+  function evPost(bit){ ev = g.gale_event_post(ev, 1<<bit, 1<<bit);                // VERIFIED bitmask
+    log(`gale::event::post_decide → events=0b${ev.toString(2).padStart(4,'0')}`); renderEv(); }
+  [0,1,2,3].forEach(b=>$('ev_p'+b).onclick=()=>evPost(b));
+  $('ev_clear').onclick=()=>{ ev=0; renderEv(); log('events cleared'); };
+  $('ev_wait').onclick=()=>{
+    const des=parseInt($('ev_des').value||'0',2)||0, all=$('ev_all').checked?1:0;
+    const d=g.gale_event_wait(ev, des, all, 1);                                     // VERIFIED (no-wait)
+    setDec($('ev_decide'), WAIT[d], d===0?'ok':(d===2?'bad':'warn'));
+    log(`gale::event::wait_decide(events=0b${ev.toString(2).padStart(4,'0')}, want=0b${des.toString(2).padStart(4,'0')}, ${all?'ALL':'ANY'}) → ${WAIT[d]}`);
+  };
+  renderEv();
 
   // ---- kiln-async scheduler (executor) ----
   const cv=$('spark'), cx=cv.getContext('2d'), hist=[]; let t=0, running=true;


### PR DESCRIPTION
Adds **gale::mutex** (lock/unlock — ownership/reentrancy/EPERM) and **gale::event** (bitmask post/wait, ANY/ALL) verified-decider panels to the live browser demo, completing the kit (sem · msgq · mutex · event). All run the actual proven gale deciders in one 3.6 KB wasm; verified in wasmtime. Updates https://pulseengine.github.io/gale/.

🤖 Generated with [Claude Code](https://claude.com/claude-code)