### PR TITLE
chore(release): bump pinned synth v0.11.48 → v0.11.50

### DIFF
--- a/.github/workflows/release-wasm.yml
+++ b/.github/workflows/release-wasm.yml
@@ -37,10 +37,10 @@ jobs:
         run: |
           . /root/.cargo/env
           # Pinned versions — bump deliberately; the manifest records them.
-          # Keep in lockstep with release.yml (synth v0.11.48 ships #359/#372,
-          # required to build the msgq module).
+          # Keep in lockstep with release.yml (synth v0.11.50: #359/#372 +
+          # #382/#378/#381 additive hardening; all three modules build clean).
           cargo install loom-cli --git https://github.com/pulseengine/loom --tag v1.1.14 --locked
-          cargo install synth-cli --git https://github.com/pulseengine/synth --tag v0.11.48 --locked
+          cargo install synth-cli --git https://github.com/pulseengine/synth --tag v0.11.50 --locked
 
       - name: Install arm toolchain (objcopy for the import renames)
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,8 @@ jobs:
   # ── Build the wasm-cross-LTO modules (gale's release "binaries") ──────────
   # ci-base has the Zephyr SDK (arm-zephyr-eabi-objcopy for the import renames);
   # loom + synth are pinned to the toolchain that builds ALL THREE modules
-  # (synth v0.11.48 ships #359/#372, required for msgq).
+  # (synth v0.11.50 ships #359/#372 + #382/#383-partial/#378/#381; all three
+  # modules verified to build clean on it — sem/mutex/msgq).
   build-wasm-dist:
     name: "wasm dist (sem + mutex + msgq, cortex-m4f)"
     runs-on: ubuntu-22.04
@@ -72,10 +73,11 @@ jobs:
         run: |
           . /root/.cargo/env
           # Pinned — bump deliberately; the manifest records the exact versions.
-          # synth v0.11.48 ships #372 (arm i64) + #359 (native-pointer .bss),
-          # both required to build the msgq module.
+          # synth v0.11.50 ships #372 (arm i64) + #359 (native-pointer .bss) +
+          # #382 (large offset materialization) + #378/#381 (fail-honestly);
+          # additive hardening over v0.11.48, all three modules build clean.
           cargo install loom-cli --git https://github.com/pulseengine/loom --tag v1.1.14 --locked
-          cargo install synth-cli --git https://github.com/pulseengine/synth --tag v0.11.48 --locked
+          cargo install synth-cli --git https://github.com/pulseengine/synth --tag v0.11.50 --locked
 
       - name: Install arm toolchain (objcopy for the import renames)
         run: |


### PR DESCRIPTION
Bumps the release-pipeline synth pin from **v0.11.48** to **v0.11.50** (latest) in `release.yml` and `release-wasm.yml`.

## Why
v0.11.50 is additive hardening over v0.11.48:
- carries the **same #359** (native-pointer `.bss`) and **#372** (arm i64 load/store) fixes the msgq module requires, plus
- **#382** (large load/store offset materialization), **#383** (partial), **#378/#381** (fail-honestly).

## Verification (local, synth v0.11.50)
All three wasm-dist modules build **clean** through the `clang → wasm-ld → loom → synth` pipeline (exit 0):

| module | `.text` |
|---|---|
| sem | 544 B |
| mutex | 956 B |
| msgq | 1292 B |

The gust dissolve body is unchanged (`gust_poll` 816 B). The final objcopy import-rename + signed-release lanes run in CI (ci-base has `arm-zephyr-eabi-objcopy`), so this PR's CI is the authoritative full-module re-verify.

## Scope
Two workflow comment+pin edits only. No code/artifact changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)