### PR TITLE
fix(browser): .instance.exports — the gust browser demo never actually booted

### DIFF
--- a/benches/gust/browser/web/index.html
+++ b/benches/gust/browser/web/index.html
@@ -127,7 +127,7 @@
   let g;
   try {
     const r = await fetch('gust.wasm');
-    g = (await WebAssembly.instantiate(await r.arrayBuffer(), {})).exports;
+    g = (await WebAssembly.instantiate(await r.arrayBuffer(), {})).instance.exports;
     g.gust_boot();
     $('status').textContent = 'booted — verified gale components + kiln scheduler live in wasm';
   } catch (e) { $('status').textContent = 'load error: ' + e; return; }


### PR DESCRIPTION
## The bug
`WebAssembly.instantiate(bufferSource, imports)` resolves to `{ module, instance }`, **not** the instance. So:
```js
g = (await WebAssembly.instantiate(await r.arrayBuffer(), {})).exports;  // undefined!
g.gust_boot();   // TypeError: Cannot read properties of undefined (reading 'gust_boot')
```
The `catch` swallowed it and `return`ed **before any button handler was registered** — so the page showed `load error: …` and every button was inert ("nothing happens no matter what I press"). The demo never booted in any browser.

## The fix
One line — read `.instance.exports`:
```js
g = (await WebAssembly.instantiate(await r.arrayBuffer(), {})).instance.exports;
```

## Verified end-to-end (headless Chromium over http)
- Page boots: status → *"booted — verified gale components + kiln scheduler live in wasm"*.
- kiln scheduler runs: poll rounds incrementing, PWM updating.
- Verified component fires in-browser: `gale::sem::give_decide` → count 0→1, **INCREMENT**.
- Only remaining console line is a harmless `favicon.ico` 404.

`web/gust.wasm` is rebuilt by the Pages workflow (gitignored); its exports (`gust_boot`, `gale_sem_give`, …) are confirmed present. Once this merges, Pages redeploys and https://pulseengine.github.io/gale/ works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)