### PR TITLE
feat(kiln): component-host slices 1+2 — wit/gale.wit world + gale-kiln host over gale::* (SWREQ-KILN-001/002)

### DIFF
--- a/crates/gale-kiln/.gitignore
+++ b/crates/gale-kiln/.gitignore
@@ -1,0 +1,2 @@
+/target
+/Cargo.lock

--- a/crates/gale-kiln/Cargo.toml
+++ b/crates/gale-kiln/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "gale-kiln"
+version = "0.1.0"
+edition = "2021"
+description = "gale kernel primitives as a WebAssembly Component implementing gale:kernel/{sem,msgq,mutex,event} (world `host`) directly over the verified gale::* decision functions — the no-C-FFI kiln host side (SWREQ-KILN-002, gale#63)."
+
+[lib]
+crate-type = ["cdylib"]
+
+[workspace]
+
+[dependencies]
+# The verified, no_std gale primitives (Verus/Rocq/Lean + Kani).
+gale = { path = "../.." }
+# Forked wit-bindgen (embedded async / amortized stream alloc).
+wit-bindgen = { git = "https://github.com/pulseengine/wit-bindgen", branch = "perf/async-stream-amortize-single-item-alloc" }
+
+[profile.release]
+opt-level = "z"
+lto = true

--- a/crates/gale-kiln/README.md
+++ b/crates/gale-kiln/README.md
@@ -1,0 +1,35 @@
+# gale-kiln — the gale kernel as a WebAssembly Component (no C FFI)
+
+Slice 2 of the kiln component-host path (Phase 2 / **SWREQ-KILN-002**; gale#63).
+
+Implements `world host` from `../../wit/gale.wit` —
+`gale:kernel/{sem,msgq,mutex,event}` — **directly over the verified `gale::*`
+decision functions**. An application component that imports `gale:kernel` gets
+its kernel decisions resolved by this component (or, on kiln, registered as host
+functions), with **no C FFI / no `extern "C"` / no `#[no_mangle]`** boundary —
+just the proven Rust (Verus/Rocq/Lean + Kani).
+
+## Proven (`./run.sh`)
+
+Builds to a wasip2 component, validates, and asserts the verified decision for
+representative inputs run behind the WIT — e.g.:
+
+```
+sem.give(0,3,false) -> increment   sem.give(3,3,false) -> saturated
+sem.give(0,3,true)  -> wake        mutex.lock(0,null,_,_) -> acquire
+msgq.put(0,4,4,_,_) -> full        event.post(0,0b101,0b1111) -> 5
+```
+
+## std/alloc
+
+The **payload is `gale` (`#![no_std]`, no alloc)** — the decisions. The wasip2
+component wrapper around it is host/dev-time scaffolding; when synth dissolves
+this to native ELF the wasm-runtime layer is elided/replaced by the thin TCB
+(see `../../wit/README.md`).
+
+## Next (slice 3)
+
+Compose an `app` component (imports `gale:kernel`) with this host — e.g. a sem/
+msgq smoke component, or the engine-control component re-pointed at the kernel —
+and run the composed component on `kiln-runtime`, closing the no-C-FFI loop on
+the actual kiln host.

--- a/crates/gale-kiln/run.sh
+++ b/crates/gale-kiln/run.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Build the gale-kiln host component and prove the verified gale::* decisions
+# run behind the gale:kernel Component Model interface (no C FFI). Asserts the
+# decision for representative inputs; exits non-zero on any mismatch.
+set -euo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+W="$HERE/target/wasm32-wasip2/release/gale_kiln.wasm"
+cargo build --release --target wasm32-wasip2
+wasm-tools component wit "$W" | grep -E 'export gale:' | sed 's/^/  /'
+wasm-tools validate --features all "$W" >/dev/null && echo "  validate: OK"
+inv() { wasmtime run -W component-model-async=y --invoke "$1" "$W" 2>/dev/null; }
+chk() { local got; got="$(inv "$1")"; if [ "$got" = "$2" ]; then echo "  [OK ] $1 -> $got"; else echo "  [BAD] $1 -> got '$got' exp '$2'"; FAIL=1; fi; }
+FAIL=0
+echo "== gale::sem::give_decide =="
+chk "give(0, 3, false)" increment
+chk "give(3, 3, false)" saturated
+chk "give(0, 3, true)"  wake
+echo "== gale::sem::take_decide =="
+chk "take(0, true)"  would-block
+chk "take(2, false)" acquired
+echo "== gale::mutex::lock_decide =="
+chk "lock(0, true, false, false)"  acquire
+chk "lock(1, false, true, false)"  reentrant
+echo "== gale::msgq::put_decide / event::post_decide =="
+chk "put(0, 4, 4, false, true)"  full     # full + no-wait -> fail
+chk "put(0, 4, 4, false, false)" pend     # full + blocking -> pend
+chk "put(0, 0, 4, false, false)" store    # space -> store
+chk "post(0, 5, 15)" 5
+exit $FAIL

--- a/crates/gale-kiln/src/lib.rs
+++ b/crates/gale-kiln/src/lib.rs
@@ -1,0 +1,99 @@
+//! gale-kiln — the gale kernel as a WebAssembly **Component** (`world host`).
+//!
+//! Implements `gale:kernel/{sem,msgq,mutex,event}` (see `../../wit/gale.wit`)
+//! directly over the verified `gale::*` decision functions — the same
+//! machine-checked logic (Verus/Rocq/Lean + Kani) that ships in the Zephyr
+//! drop-in and the wasm-cross-LTO modules. This is the **no-C-FFI host side**
+//! (Phase 2 / SWREQ-KILN-002): an application component imports `gale:kernel`
+//! and these decisions resolve to direct Rust calls into `gale`.
+//!
+//! Enum mapping uses the crate's stable `as i32` discriminants (the same
+//! convention the browser demo uses); declaration order in the WIT matches the
+//! gale `Decision` enums, so the mapping is a straight discriminant copy.
+#![allow(warnings)]
+
+wit_bindgen::generate!({
+    world: "host",
+    path: "../../wit",
+});
+
+use exports::gale::kernel::event::Guest as EventGuest;
+use exports::gale::kernel::msgq::{GetDecision, Guest as MsgqGuest, PutDecision};
+use exports::gale::kernel::mutex::{Guest as MutexGuest, LockDecision, UnlockDecision};
+use exports::gale::kernel::sem::{GiveDecision, Guest as SemGuest, TakeDecision};
+use exports::gale::kernel::event::WaitDecision;
+
+struct Component;
+
+impl SemGuest for Component {
+    fn give(count: u32, limit: u32, has_waiter: bool) -> GiveDecision {
+        match gale::sem::give_decide(count, limit, has_waiter) as i32 {
+            0 => GiveDecision::Wake,
+            1 => GiveDecision::Increment,
+            _ => GiveDecision::Saturated,
+        }
+    }
+    fn take(count: u32, is_no_wait: bool) -> TakeDecision {
+        match gale::sem::take_decide(count, is_no_wait) as i32 {
+            0 => TakeDecision::Acquired,
+            1 => TakeDecision::WouldBlock,
+            _ => TakeDecision::Pend,
+        }
+    }
+}
+
+impl MsgqGuest for Component {
+    fn put(write_idx: u32, used: u32, max: u32, has_waiter: bool, is_no_wait: bool) -> PutDecision {
+        match gale::msgq::put_decide(write_idx, used, max, has_waiter, is_no_wait).decision as i32 {
+            0 => PutDecision::Store,
+            1 => PutDecision::WakeReader,
+            2 => PutDecision::Pend,
+            _ => PutDecision::Full,
+        }
+    }
+    fn get(read_idx: u32, used: u32, max: u32, has_waiter: bool, is_no_wait: bool) -> GetDecision {
+        match gale::msgq::get_decide(read_idx, used, max, has_waiter, is_no_wait).decision as i32 {
+            0 => GetDecision::Read,
+            1 => GetDecision::WakeWriter,
+            2 => GetDecision::Pend,
+            _ => GetDecision::Empty,
+        }
+    }
+}
+
+impl MutexGuest for Component {
+    fn lock(lock_count: u32, owner_is_null: bool, owner_is_current: bool, is_no_wait: bool) -> LockDecision {
+        match gale::mutex::lock_decide(lock_count, owner_is_null, owner_is_current, is_no_wait) as i32 {
+            0 => LockDecision::Acquire,
+            1 => LockDecision::Reentrant,
+            2 => LockDecision::Pend,
+            3 => LockDecision::Busy,
+            _ => LockDecision::Overflow,
+        }
+    }
+    fn unlock(lock_count: u32, owner_is_null: bool, owner_is_current: bool) -> UnlockDecision {
+        match gale::mutex::unlock_decide(lock_count, owner_is_null, owner_is_current) as i32 {
+            0 => UnlockDecision::NotLocked,
+            1 => UnlockDecision::NotOwner,
+            2 => UnlockDecision::Released,
+            _ => UnlockDecision::FullyUnlocked,
+        }
+    }
+}
+
+impl EventGuest for Component {
+    fn post(current_events: u32, new_events: u32, mask: u32) -> u32 {
+        gale::event::post_decide(current_events, new_events, mask)
+    }
+    fn wait(current_events: u32, desired: u32, wait_all: bool, is_no_wait: bool) -> WaitDecision {
+        // gale wait_type: 0 = ANY, 1 = ALL
+        let wait_type: u8 = if wait_all { 1 } else { 0 };
+        match gale::event::wait_decide(current_events, desired, wait_type, is_no_wait).decision as i32 {
+            0 => WaitDecision::Matched,
+            1 => WaitDecision::Pend,
+            _ => WaitDecision::Timeout,
+        }
+    }
+}
+
+export!(Component);

--- a/wit/README.md
+++ b/wit/README.md
@@ -1,0 +1,78 @@
+# `wit/gale.wit` — the gale kernel-primitives Component Model world
+
+The dependency-root of the **kiln component-host** path (Phase 2,
+`SWREQ-KILN-001`; gale#63 / gale#74). It defines the verified gale kernel
+primitives as WebAssembly **Component Model** interfaces so that a gale
+application *component* can `import` them and the **kiln host provides them as
+direct Rust calls into `gale::*`** — eliminating the C FFI boundary.
+
+## Interfaces
+
+`gale:kernel@0.1.0` — `sem`, `msgq`, `mutex`, `event`. Each function is the
+SAME machine-checked decision the crate already ships (Verus/Rocq/Lean + Kani):
+`sem.give` ↔ `gale::sem::give_decide`, `msgq.put` ↔ `gale::msgq::put_decide`,
+etc. The WIT `enum` discriminants are in declaration order to match the crate's
+`Decision` enums.
+
+Two worlds:
+- **`app`** — what a gale application component imports (the kernel it runs on).
+- **`host`** — what the kiln host (or the Zephyr drop-in) exports; `gale-kiln`
+  registers `gale::*` behind these.
+
+## Status (honest)
+
+- ✅ **WIT authored + validated** — round-trips through `wasm-tools component
+  wit`; `wit-bindgen rust --world app` generates clean guest bindings.
+- ⬜ **`gale-kiln` host crate** (`SWREQ-KILN-002`: register `gale::*` as kiln
+  host functions) — not built yet; the next slice.
+- ⬜ **End-to-end run** — instantiate an `app` component on `kiln-runtime` with
+  the `host` world wired to `gale::*`. kiln-runtime *has* component-model
+  support (`component_impl.rs`, `component_unified.rs`, async example) but
+  hosting an external component this way needs validation.
+
+## `std` / `alloc` reality — be precise about which parts
+
+The dissolved **payload** (what synth turns into native ELF and what actually
+runs on-device) is already `no_std` + `no_alloc`:
+
+| part | status |
+|---|---|
+| gale verified primitives (`gale`, `src/lib.rs`) | **`#![no_std]`, no alloc** — pure decision fns |
+| kiln-async scheduler core (`kiln-async`) | **`#![no_std]`, no `Box`/`Vec`/alloc** in core |
+| browser demo crate | **`#![no_std]`** |
+| wasm-dissolve C shim | **`-nostdlib`, freestanding** |
+
+The `std`/`alloc` that exists is in the **host/dev-time runtime machinery**, not
+the payload:
+
+| part | uses | note |
+|---|---|---|
+| forked wit-bindgen async stream runtime | **alloc** (`Vec` stream buffers) | the amortized-alloc work; a wasm-host concern |
+| `engine_control` component crate | `std` (not yet `#![no_std]`); async path pulls the alloc above | sync `step` is no_std/no_alloc-capable |
+| `kiln-error` `recovery.rs` | **alloc** | gated out by kiln#338 (`no_alloc` feature) |
+
+**Why this is mostly fine — synth puts the wasm to ELF.** Because the component
+is *dissolved* (wasm → loom → synth → native ELF), the wasm async/runtime layer
+and its allocations are **elided or replaced by the thin native TCB** — they do
+not land on the device. So the `no_std`/`no_alloc` obligation is on the
+*payload* (above, already met), and the runtime `alloc` is a testing/host
+artifact that falls away on dissolve. Where we *do* keep alloc on-target (e.g.
+the scheduler's recovery path), the plan is to introduce it as `no_alloc`
+deliberately (kiln#338) — not leave it implicit.
+
+## Sequence
+
+1. **`wit/gale.wit`** (this file) — the contract. ✅
+2. **`gale-kiln`** crate — implement the `host` world over `gale::*`
+   (`SWREQ-KILN-002`).
+3. **Run an `app` component on kiln** — e.g. the engine-control component
+   (`benches/engine_control/wasm-component`) re-pointed at `gale:kernel`, or a
+   sem/msgq smoke component — closing the no-C-FFI loop.
+4. Then the `embedded-hal-async` driver leg (`SAC-BYOOS-HALSEAM`) sits on top.
+
+## Regenerate / check
+
+```sh
+wasm-tools component wit wit/gale.wit          # validate
+wit-bindgen rust --world app wit/gale.wit --out-dir /tmp/g   # guest bindings
+```

--- a/wit/gale.wit
+++ b/wit/gale.wit
@@ -1,0 +1,67 @@
+package gale:kernel@0.1.0;
+
+// The verified gale kernel primitives as WebAssembly Component Model
+// interfaces (Phase 2 / SWREQ-KILN-001). These are the SAME proven decision
+// functions that ship in the Zephyr drop-in, the wasm-cross-LTO modules, and
+// the browser demo (gale::sem::give_decide, gale::msgq::put_decide, …) —
+// machine-checked by Verus/Rocq/Lean + Kani. A gale application *component*
+// IMPORTS these; the kiln host PROVIDES them as direct Rust calls into gale::*
+// (no C FFI). Enum discriminants match the crate's Decision enums.
+
+interface sem {
+    /// gale::sem::give_decide — Verus-proven: no overflow.
+    enum give-decision { wake, increment, saturated }
+    give: func(count: u32, limit: u32, has-waiter: bool) -> give-decision;
+
+    /// gale::sem::take_decide — Verus-proven: no underflow.
+    enum take-decision { acquired, would-block, pend }
+    take: func(count: u32, is-no-wait: bool) -> take-decision;
+}
+
+interface msgq {
+    /// gale::msgq::put_decide — Verus + Kani-proven ring arithmetic.
+    enum put-decision { store, wake-reader, pend, full }
+    put: func(write-idx: u32, used: u32, max: u32, has-waiter: bool, is-no-wait: bool) -> put-decision;
+
+    /// gale::msgq::get_decide — Verus + Kani-proven.
+    enum get-decision { read, wake-writer, pend, empty }
+    get: func(read-idx: u32, used: u32, max: u32, has-waiter: bool, is-no-wait: bool) -> get-decision;
+}
+
+interface mutex {
+    /// gale::mutex::lock_decide — Verus-proven: ownership, reentrancy, no overflow.
+    enum lock-decision { acquire, reentrant, pend, busy, overflow }
+    lock: func(lock-count: u32, owner-is-null: bool, owner-is-current: bool, is-no-wait: bool) -> lock-decision;
+
+    /// gale::mutex::unlock_decide — Verus-proven: -EINVAL/-EPERM, reentrant, no underflow.
+    enum unlock-decision { not-locked, not-owner, released, fully-unlocked }
+    unlock: func(lock-count: u32, owner-is-null: bool, owner-is-current: bool) -> unlock-decision;
+}
+
+interface event {
+    /// gale::event::post_decide — Verus-proven bitmask algebra; returns new event mask.
+    post: func(current-events: u32, new-events: u32, mask: u32) -> u32;
+
+    /// gale::event::wait_decide — wait-type: any=false / all=true.
+    enum wait-decision { matched, pend, timeout }
+    wait: func(current-events: u32, desired: u32, wait-all: bool, is-no-wait: bool) -> wait-decision;
+}
+
+/// What a gale application component imports: the verified kernel primitives,
+/// provided by the kiln host. The component's own logic (control, decode,
+/// voting) is the wasm body; the kernel decisions are proven gale::* calls.
+world app {
+    import sem;
+    import msgq;
+    import mutex;
+    import event;
+}
+
+/// What the kiln host (or the Zephyr drop-in) provides — the same interfaces,
+/// exported. `gale-kiln` registers gale::* behind these.
+world host {
+    export sem;
+    export msgq;
+    export mutex;
+    export event;
+}


### PR DESCRIPTION
First slice of the **kiln component-host** path (gale#63 / Phase 2): the dependency-root WIT world.

`wit/gale.wit` (`gale:kernel@0.1.0`) defines gale's verified kernel primitives — `sem`, `msgq`, `mutex`, `event` — as Component Model interfaces. An application **component imports** them (`world app`); the **kiln host provides** them (`world host`) as direct Rust calls into `gale::*` — no C FFI. Each function is the same machine-checked decision the crate already ships (Verus/Rocq/Lean + Kani); WIT `enum` discriminants are in declaration order to match the crate's `Decision` enums.

**Validated:** round-trips through `wasm-tools component wit`; `wit-bindgen rust --world app` generates clean guest bindings (626 lines).

**std/alloc precision** (per the embedded discipline): the README states exactly which parts are `no_std`/`no_alloc` (the dissolved payload — gale primitives + kiln-async scheduler core — already are) vs `std`/`alloc` (host/dev-time wasm-runtime machinery: forked wit-bindgen stream buffers, kiln-error recovery), and why the latter falls away when **synth dissolves wasm → ELF** (the wasm runtime is elided/replaced by the thin native TCB) or is gated `no_alloc` (kiln#338).

**Next slice:** `gale-kiln` host crate (SWREQ-KILN-002) implementing `world host` over `gale::*`, then run an `app` component on `kiln-runtime`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)