### PR TITLE
feat(kiln): slice 3 — compose app+gale-kiln, the no-C-FFI component loop

### DIFF
--- a/crates/gale-app-demo/.gitignore
+++ b/crates/gale-app-demo/.gitignore
@@ -1,0 +1,2 @@
+/target
+/Cargo.lock

--- a/crates/gale-app-demo/Cargo.toml
+++ b/crates/gale-app-demo/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "gale-app-demo"
+version = "0.1.0"
+edition = "2021"
+description = "A gale application component that IMPORTS gale:kernel (composed with gale-kiln to resolve to verified gale::*). Slice 3 of the kiln component-host path."
+
+[lib]
+crate-type = ["cdylib"]
+
+[workspace]
+
+[dependencies]
+wit-bindgen = { git = "https://github.com/pulseengine/wit-bindgen", branch = "perf/async-stream-amortize-single-item-alloc" }
+
+[profile.release]
+opt-level = "z"
+lto = true

--- a/crates/gale-app-demo/README.md
+++ b/crates/gale-app-demo/README.md
@@ -1,0 +1,33 @@
+# gale-app-demo — the no-C-FFI component loop (kiln component-host slice 3)
+
+A gale **application component** that *imports* `gale:kernel` (sem, msgq) — it
+contains **no kernel logic**. Composed with [`gale-kiln`](../gale-kiln) (which
+provides `gale:kernel` over the verified `gale::*` decisions), the app's kernel
+calls resolve to proven Rust across the Component Model boundary — **no C FFI,
+no `extern "C"`, no `#[no_mangle]`**.
+
+## Proven (`./run.sh`)
+
+Builds app + host, **composes them with `wac`**, runs the result on wasmtime:
+
+```
+composed imports remaining: (none — fully satisfied)
+run-demo() = 53            # would-block(1) | increment(1)<<2 | full(3)<<4
+```
+
+i.e. the app called `sem.take/give` and `msgq.put`; each resolved to the
+machine-checked `gale::*` decision in the composed host.
+
+## Status — host backings
+
+| host | status |
+|---|---|
+| **wasmtime** (dev/test) | ✅ composed loop runs (`run.sh`) |
+| **kiln-runtime** (target) | ⛔ kilnd component-model support is *temporarily disabled*; runtime component API is internal/test-grade — tracked as a kiln-host gap. The composition is host-agnostic, so it lands on kiln unchanged once kilnd enables components. |
+| **dissolved-native** | future: synth the composed core to ELF (the library-OS backing) |
+
+## The loop, one line
+
+`app (imports gale:kernel)` + `gale-kiln (gale::* behind gale:kernel)` --wac-->
+`composed` → runs → verified decisions. The same composition is what kiln will
+host and what synth will dissolve to a native library-OS image.

--- a/crates/gale-app-demo/run.sh
+++ b/crates/gale-app-demo/run.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Slice 3: the no-C-FFI component loop. Build the app component (imports
+# gale:kernel) + the gale-kiln host (provides gale:kernel over gale::*),
+# COMPOSE them (wac), and run — proving the app's kernel calls resolve to the
+# verified gale::* decisions with no C FFI. Asserts the packed result.
+#
+# Tools: cargo + wasm32-wasip2, wac, wasmtime (>=42 for -W component-model-async).
+set -euo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+APP="$HERE/target/wasm32-wasip2/release/gale_app_demo.wasm"
+KILN="$HERE/../gale-kiln/target/wasm32-wasip2/release/gale_kiln.wasm"
+OUT="$HERE/target/composed.wasm"
+
+echo "== build app (imports gale:kernel) + gale-kiln (provides it) =="
+cargo build --release --target wasm32-wasip2
+( cd "$HERE/../gale-kiln" && cargo build --release --target wasm32-wasip2 )
+
+echo "== compose: plug gale-kiln into the app's gale:kernel imports =="
+wac plug "$APP" --plug "$KILN" -o "$OUT"
+echo "  composed imports remaining:"
+wasm-tools component wit "$OUT" | grep -E 'import' | sed 's/^/    /' || echo "    (none — fully satisfied)"
+
+echo "== run composed component on wasmtime =="
+got="$(wasmtime run -W component-model-async=y --invoke 'run-demo()' "$OUT" 2>/dev/null)"
+# expected: take(0,true)=would-block(1) | give(0,3,false)=increment(1)<<2 | put(0,4,4,_,true)=full(3)<<4
+exp=53
+if [ "$got" = "$exp" ]; then echo "  [OK ] run-demo() = $got  (would-block|increment|full)"; else echo "  [BAD] run-demo() = $got exp $exp"; exit 1; fi
+echo "== loop proven: app -> composed -> verified gale::* (no C FFI) =="

--- a/crates/gale-app-demo/src/lib.rs
+++ b/crates/gale-app-demo/src/lib.rs
@@ -1,0 +1,23 @@
+//! gale-app-demo — a gale application component that IMPORTS gale:kernel.
+//! It contains no kernel logic; composed with gale-kiln the imports resolve to
+//! the verified gale::* decisions. Proves the no-C-FFI component loop.
+#![allow(warnings)]
+wit_bindgen::generate!({ world: "demo", path: "wit", generate_all });
+
+use gale::kernel::{sem, msgq};
+
+struct Component;
+
+impl Guest for Component {
+    fn run_demo() -> u32 {
+        // take from an empty sem, no-wait -> WOULD_BLOCK (=1)
+        let t = sem::take(0, true) as u32;
+        // give below limit, no waiter -> INCREMENT (=1)
+        let g = sem::give(0, 3, false) as u32;
+        // put into a full queue, no-wait -> FULL (=3)
+        let p = msgq::put(0, 4, 4, false, true) as u32;
+        (t & 0x3) | ((g & 0x3) << 2) | ((p & 0x3) << 4)
+    }
+}
+
+export!(Component);

--- a/crates/gale-app-demo/wit/deps/kernel/gale.wit
+++ b/crates/gale-app-demo/wit/deps/kernel/gale.wit
@@ -1,0 +1,67 @@
+package gale:kernel@0.1.0;
+
+// The verified gale kernel primitives as WebAssembly Component Model
+// interfaces (Phase 2 / SWREQ-KILN-001). These are the SAME proven decision
+// functions that ship in the Zephyr drop-in, the wasm-cross-LTO modules, and
+// the browser demo (gale::sem::give_decide, gale::msgq::put_decide, …) —
+// machine-checked by Verus/Rocq/Lean + Kani. A gale application *component*
+// IMPORTS these; the kiln host PROVIDES them as direct Rust calls into gale::*
+// (no C FFI). Enum discriminants match the crate's Decision enums.
+
+interface sem {
+    /// gale::sem::give_decide — Verus-proven: no overflow.
+    enum give-decision { wake, increment, saturated }
+    give: func(count: u32, limit: u32, has-waiter: bool) -> give-decision;
+
+    /// gale::sem::take_decide — Verus-proven: no underflow.
+    enum take-decision { acquired, would-block, pend }
+    take: func(count: u32, is-no-wait: bool) -> take-decision;
+}
+
+interface msgq {
+    /// gale::msgq::put_decide — Verus + Kani-proven ring arithmetic.
+    enum put-decision { store, wake-reader, pend, full }
+    put: func(write-idx: u32, used: u32, max: u32, has-waiter: bool, is-no-wait: bool) -> put-decision;
+
+    /// gale::msgq::get_decide — Verus + Kani-proven.
+    enum get-decision { read, wake-writer, pend, empty }
+    get: func(read-idx: u32, used: u32, max: u32, has-waiter: bool, is-no-wait: bool) -> get-decision;
+}
+
+interface mutex {
+    /// gale::mutex::lock_decide — Verus-proven: ownership, reentrancy, no overflow.
+    enum lock-decision { acquire, reentrant, pend, busy, overflow }
+    lock: func(lock-count: u32, owner-is-null: bool, owner-is-current: bool, is-no-wait: bool) -> lock-decision;
+
+    /// gale::mutex::unlock_decide — Verus-proven: -EINVAL/-EPERM, reentrant, no underflow.
+    enum unlock-decision { not-locked, not-owner, released, fully-unlocked }
+    unlock: func(lock-count: u32, owner-is-null: bool, owner-is-current: bool) -> unlock-decision;
+}
+
+interface event {
+    /// gale::event::post_decide — Verus-proven bitmask algebra; returns new event mask.
+    post: func(current-events: u32, new-events: u32, mask: u32) -> u32;
+
+    /// gale::event::wait_decide — wait-type: any=false / all=true.
+    enum wait-decision { matched, pend, timeout }
+    wait: func(current-events: u32, desired: u32, wait-all: bool, is-no-wait: bool) -> wait-decision;
+}
+
+/// What a gale application component imports: the verified kernel primitives,
+/// provided by the kiln host. The component's own logic (control, decode,
+/// voting) is the wasm body; the kernel decisions are proven gale::* calls.
+world app {
+    import sem;
+    import msgq;
+    import mutex;
+    import event;
+}
+
+/// What the kiln host (or the Zephyr drop-in) provides — the same interfaces,
+/// exported. `gale-kiln` registers gale::* behind these.
+world host {
+    export sem;
+    export msgq;
+    export mutex;
+    export event;
+}

--- a/crates/gale-app-demo/wit/world.wit
+++ b/crates/gale-app-demo/wit/world.wit
@@ -1,0 +1,12 @@
+package gale:app-demo@0.1.0;
+
+/// A tiny gale application *component*: it imports the verified kernel
+/// primitives (gale:kernel) — it does NOT implement them. Composed with
+/// gale-kiln (which provides them over gale::*), the kernel calls resolve to
+/// proven Rust with no C FFI. `run-demo` exercises a few decisions and packs
+/// the discriminants so the composed result is verifiable.
+world demo {
+    import gale:kernel/sem@0.1.0;
+    import gale:kernel/msgq@0.1.0;
+    export run-demo: func() -> u32;
+}


### PR DESCRIPTION
Slice 3 of the kiln component-host path (gale#63). A gale **application component** (`crates/gale-app-demo`) that *imports* `gale:kernel` (no kernel logic of its own), **composed via `wac`** with `gale-kiln` (provides `gale:kernel` over the verified `gale::*`).

## Proven (`./run.sh`)
```
composed imports remaining: (none — fully satisfied)
run-demo() = 53     # would-block(1) | increment(1)<<2 | full(3)<<4
```
The app called `sem.take/give` + `msgq.put`; each resolved to the machine-checked `gale::*` decision in the composed host — **no C FFI, no extern "C", no #[no_mangle]**.

## Host backings
| host | status |
|---|---|
| wasmtime (dev/test) | ✅ composed loop runs |
| kiln-runtime (target) | ⛔ kilnd component-model support *temporarily disabled*; runtime component API internal/test-grade — filed as kiln-host gap. Composition is host-agnostic → lands on kiln unchanged once enabled. |
| dissolved-native | future: synth the composed core to a library-OS ELF |

Together with #84/#85 this completes slices 1–3 at the wasmtime backing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)