### PR TITLE
ci: swap full zephyr ci: image → ci-base across all workflows (fix recurring ENOSPC, gale#73)

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -58,11 +58,12 @@ jobs:
     name: Zephyr C Coverage
     runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/zephyrproject-rtos/ci:v0.29.0
-      options: --user root
+      image: ghcr.io/zephyrproject-rtos/ci-base:v0.29.0
+      options: --user root --volume /mnt:/mnt
     env:
       HOME: /root
       DOCKER_CONFIG: /tmp/.docker
+      GITHUB_TOKEN: ${{ github.token }}
     steps:
       - name: Checkout Gale
         uses: actions/checkout@v6
@@ -82,7 +83,7 @@ jobs:
           west init -m https://github.com/pulseengine/zephyr.git --mr gale/sem-replacement zephyr-workspace
           cd zephyr-workspace
           west update --narrow -o=--depth=1
-          for attempt in 1 2 3; do west sdk install -t arm-zephyr-eabi && break || sleep 5; done
+          for attempt in 1 2 3; do west sdk install -t arm-zephyr-eabi --personal-access-token "${GITHUB_TOKEN}" && break || sleep 5; done
 
       - name: Run twister with coverage
         run: |

--- a/.github/workflows/engine-bench-renode-flight.yml
+++ b/.github/workflows/engine-bench-renode-flight.yml
@@ -49,8 +49,8 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 180
     container:
-      image: ghcr.io/zephyrproject-rtos/ci:v0.29.0
-      options: --user root
+      image: ghcr.io/zephyrproject-rtos/ci-base:v0.29.0
+      options: --user root --volume /mnt:/mnt
     env:
       HOME: /root
       DOCKER_CONFIG: /tmp/.docker
@@ -186,7 +186,7 @@ jobs:
             echo "run_attempt:           ${{ github.run_attempt }}"
             echo "gale_sha:              ${{ github.sha }}"
             echo "gale_ref:              ${{ github.ref }}"
-            echo "container:             ghcr.io/zephyrproject-rtos/ci:v0.29.0"
+            echo "container:             ghcr.io/zephyrproject-rtos/ci-base:v0.29.0"
             echo "runner:                $(uname -srm)"
             echo "---"
             echo "# Toolchain"

--- a/.github/workflows/engine-bench-renode-lto.yml
+++ b/.github/workflows/engine-bench-renode-lto.yml
@@ -44,8 +44,8 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 120
     container:
-      image: ghcr.io/zephyrproject-rtos/ci:v0.29.0
-      options: --user root
+      image: ghcr.io/zephyrproject-rtos/ci-base:v0.29.0
+      options: --user root --volume /mnt:/mnt
     env:
       HOME: /root
       DOCKER_CONFIG: /tmp/.docker

--- a/.github/workflows/engine-bench-renode-synth.yml
+++ b/.github/workflows/engine-bench-renode-synth.yml
@@ -71,8 +71,8 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 300
     container:
-      image: ghcr.io/zephyrproject-rtos/ci:v0.29.0
-      options: --user root
+      image: ghcr.io/zephyrproject-rtos/ci-base:v0.29.0
+      options: --user root --volume /mnt:/mnt
     env:
       HOME: /root
       DOCKER_CONFIG: /tmp/.docker
@@ -532,7 +532,7 @@ jobs:
             echo "run_attempt:           ${{ github.run_attempt }}"
             echo "gale_sha:              ${{ github.sha }}"
             echo "gale_ref:              ${{ github.ref }}"
-            echo "container:             ghcr.io/zephyrproject-rtos/ci:v0.29.0"
+            echo "container:             ghcr.io/zephyrproject-rtos/ci-base:v0.29.0"
             echo "runner:                $(uname -srm)"
             echo "---"
             echo "# Toolchain"

--- a/.github/workflows/engine-bench-renode.yml
+++ b/.github/workflows/engine-bench-renode.yml
@@ -48,8 +48,8 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 90
     container:
-      image: ghcr.io/zephyrproject-rtos/ci:v0.29.0
-      options: --user root
+      image: ghcr.io/zephyrproject-rtos/ci-base:v0.29.0
+      options: --user root --volume /mnt:/mnt
     env:
       HOME: /root
       DOCKER_CONFIG: /tmp/.docker

--- a/.github/workflows/engine-bench-smoke.yml
+++ b/.github/workflows/engine-bench-smoke.yml
@@ -48,8 +48,8 @@ jobs:
   smoke:
     runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/zephyrproject-rtos/ci:v0.29.0
-      options: --user root
+      image: ghcr.io/zephyrproject-rtos/ci-base:v0.29.0
+      options: --user root --volume /mnt:/mnt
     env:
       HOME: /root
       DOCKER_CONFIG: /tmp/.docker

--- a/.github/workflows/llvm-lto.yml
+++ b/.github/workflows/llvm-lto.yml
@@ -42,7 +42,7 @@ jobs:
     name: "LLVM LTO build + size comparison"
     runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/zephyrproject-rtos/ci:v0.29.0
+      image: ghcr.io/zephyrproject-rtos/ci-base:v0.29.0
       # Mount the runner's large ephemeral scratch disk (/mnt, ~70 GB). These jobs
       # run multiple west builds on the full `ci` image — more disk than a
       # single-build job — so the west workspace + build dirs go on /mnt to avoid
@@ -304,7 +304,7 @@ jobs:
     name: "llvm-lto-test"
     runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/zephyrproject-rtos/ci:v0.29.0
+      image: ghcr.io/zephyrproject-rtos/ci-base:v0.29.0
       # Mount the runner's large ephemeral scratch disk (/mnt, ~70 GB). These jobs
       # run multiple west builds on the full `ci` image — more disk than a
       # single-build job — so the west workspace + build dirs go on /mnt to avoid

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -141,8 +141,8 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 45
     container:
-      image: ghcr.io/zephyrproject-rtos/ci:v0.29.0
-      options: --user root
+      image: ghcr.io/zephyrproject-rtos/ci-base:v0.29.0
+      options: --user root --volume /mnt:/mnt
     env:
       HOME: /root
       DOCKER_CONFIG: /tmp/.docker

--- a/.github/workflows/renode-tests.yml
+++ b/.github/workflows/renode-tests.yml
@@ -29,8 +29,8 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 30
     container:
-      image: ghcr.io/zephyrproject-rtos/ci:v0.29.0
-      options: --user root
+      image: ghcr.io/zephyrproject-rtos/ci-base:v0.29.0
+      options: --user root --volume /mnt:/mnt
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Fixes the **recurring ENOSPC** that's been failing nearly every PR (llvm-lto, coverage, board/renode jobs) — **gale#73**.

## Cause
`ghcr.io/zephyrproject-rtos/ci:v0.29.0` (the *full* Zephyr CI image) doesn't fit the runner disk: `Free space left: 3 MB` → `failed to register layer … no space left on device` on the zephyr-sdk layers, during the docker pull. `zephyr-tests.yml` / `release*.yml` already moved to the small **`ci-base`** image + self-install only the SDK they need; this extends that proven pattern to the remaining **9** workflows.

## Why it's safe
Every one of these already runs `west sdk install -t arm-zephyr-eabi` (or `${SDK_TARGET}`) and targets **ARM-only boards** (cortex-m3/r5, mps2/an521, stm32f4, nucleo_l552 — **zero riscv**). So the full image was pure redundancy; `ci-base` + the existing install provides exactly the arch each needs.

## Changes
`coverage`, `llvm-lto`, `nightly`, `engine-bench-{smoke,renode,renode-lto,renode-flight,renode-synth}`, `renode-tests`:
- `image: ci:v0.29.0` → `ci-base:v0.29.0`
- add `--volume /mnt:/mnt` (~70 GB scratch) to containers missing it
- `coverage`: add `--personal-access-token "${GITHUB_TOKEN}"` + `GITHUB_TOKEN` env to its `west sdk install` (was anonymous → API-rate-limit prone on ci-base)

**Oracle:** this PR's own CI must complete without the ENOSPC docker-pull failure (the same jobs that fail on #90/#91). Closes gale#73.

🤖 Generated with [Claude Code](https://claude.com/claude-code)