### PR TITLE
fix(x86-smp): close residual smp_spinlock boot-hang — early-boot NULL-_current arm on lock + unlock paths (closes #98)

### DIFF
--- a/zephyr/gale_spinlock_validate.c
+++ b/zephyr/gale_spinlock_validate.c
@@ -47,6 +47,23 @@ bool z_spin_lock_valid(struct k_spinlock *l)
 {
 	uintptr_t thread_cpu = l->thread_cpu;
 
+	/* Early-boot arm, symmetric with z_spin_unlock_valid's zero-tag arm
+	 * (#58, gale#98). Before a CPU's dummy thread exists, _current == NULL,
+	 * so set_owner encoded the tag as (cpu_id | NULL) == cpu_id — a non-zero
+	 * tag on an AP (CPU id != 0). A re-acquire on that same still-NULL CPU
+	 * would then match (thread_cpu & CPU_MASK) == _current_cpu->id and be
+	 * reported as a same-CPU deadlock, which recurses assert->printk->
+	 * spinlock pre-console and hangs boot silently (the AP-bringup race that
+	 * #58 left unpatched on this arm; see gale#98). Real deadlock detection
+	 * needs a real owning thread, so skip the check while _current == NULL —
+	 * stock spinlock_validate.c tolerates the boot tag the same way. Inert
+	 * post-boot: once threads exist _current != NULL and the full Verus-backed
+	 * check below runs, protected by its thread_ptr_valid precondition.
+	 */
+	if (_current == NULL) {
+		return true;
+	}
+
 	return gale_spin_lock_valid(thread_cpu,
 				    _current_cpu->id) != 0;
 }
@@ -59,6 +76,20 @@ bool z_spin_unlock_valid(struct k_spinlock *l)
 	 * matching the original C semantics.
 	 */
 	l->thread_cpu = 0;
+
+	/* Early-boot arm, symmetric with z_spin_lock_valid and the zero-tag arm
+	 * below (#58, gale#98). On an AP before its dummy thread exists,
+	 * _current == NULL and the tag is (cpu_id | NULL) == cpu_id != 0, so the
+	 * zero-tag arm below does NOT catch it and we would call the FFI with a
+	 * NULL thread — violating gale_spin_unlock_valid's thread_ptr_valid
+	 * (non-NULL) precondition (erased at the C boundary). Validation needs a
+	 * real owning thread, so skip it while _current == NULL (the owner is
+	 * already cleared above). Must precede the _current deref below. Inert
+	 * post-boot: _current != NULL, so the full check runs.
+	 */
+	if (_current == NULL) {
+		return true;
+	}
 
 	/* Edge case: an ISR aborted _current, leaving it as a dummy
 	 * thread.  The spinlock was locked by the pre-abort thread,


### PR DESCRIPTION
Closes #98. Root-cause hunt: a deep dive (3 perspectives, re-derived from live source) traced the recurring intermittent `smp_spinlock (qemu_x86_64, SMP)` boot hang to the **unpatched continuation of #58**.

## Mechanism
#58 made only `z_spin_unlock_valid`'s `thread_cpu == 0` arm early-boot-tolerant. The **lock path** and the **unlock path's AP case** stayed asymmetric:

During AP (CPU1) bringup, before CPU1's dummy thread exists, `_current == NULL`, so `set_owner` encodes the tag `(cpu_id | NULL) == cpu_id` — **non-zero on an AP**. Then:
- `z_spin_lock_valid` sees `(thread_cpu & CPU_MASK) == _current_cpu->id` → **false same-CPU deadlock** on a lock CPU1 doesn't hold;
- `z_spin_unlock_valid`'s zero-tag arm only catches CPU0 (tag 0); the AP tag (≠0) **falls through to the FFI with a NULL thread**, violating `gale_spin_unlock_valid`'s `thread_ptr_valid` (non-NULL) precondition (erased at the C boundary).

With `SPIN_VALIDATE` + `ASSERT` (ztest default), the false reject recurses `assert→printk→spinlock` **pre-console → silent boot hang** — the exact failure mode #58 fixed, on the arms it didn't patch. qemu TCG-SMP scheduling sets the window width → **intermittent** (mostly green; recurs as a non-blocking red — the job is `continue-on-error`).

**Why spinlock and not semaphore/sched:** `tests/kernel/spinlock` is the only SMP suite that hammers `k_spin_lock` on CPU1 *immediately* as it comes online, densely hitting the NULL-`_current` window. (semaphore/sched are consistently green on the same board+overlays — localizing the bug to the validate path.)

## Fix
Skip validation while `_current == NULL` on **both** arms — real deadlock/owner checks need a real owning thread, and stock `spinlock_validate.c` tolerates the boot tag the same way.
- Additive, **C-shim only** — the verified Rust core (`src/spinlock_validate.rs`) and its Verus proofs are untouched.
- **Inert post-boot:** once `_current != NULL` the full check runs, so post-boot deadlock detection is unchanged (no safety regression).

## Verification (honest)
Sound by construction (mirrors #58; provably inert post-boot). It **cannot** be proven in one CI run — the hang is intermittent, so a single green `smp_spinlock` is necessary, not sufficient; the real verifier is flake-rate over many runs. The definitive discriminator (in #98): build with `CONFIG_GALE_KERNEL_SPINLOCK_VALIDATE=n` — if that's also green, the gale-validate path is confirmed as the cause. Leaving `continue-on-error: true` in place until the flake is gone over a run window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)