### PR TITLE
ci(zephyr-tests): install Zephyr SDK onto /mnt not /root — residual gale#73 ENOSPC

### DIFF
--- a/.github/workflows/zephyr-tests.yml
+++ b/.github/workflows/zephyr-tests.yml
@@ -170,7 +170,13 @@ jobs:
           west init -m https://github.com/pulseengine/zephyr.git --mr gale/sem-replacement /mnt/zephyr-workspace
           cd /mnt/zephyr-workspace
           west update --narrow -o=--depth=1
-          for attempt in 1 2 3; do west sdk install -t arm-zephyr-eabi --personal-access-token "${GITHUB_TOKEN}" && break || sleep 5; done
+          # --install-base /mnt: extract the SDK onto the big ephemeral disk, not
+          # $HOME (=/root) on the small host fs. The default home-dir extract
+          # tips the runner into ENOSPC (writing its own diag log) during the
+          # zephyr-sdk download — the residual gale#73 vector left after the
+          # workspace was moved to /mnt. The CMake package registry still finds
+          # the SDK regardless of install location.
+          for attempt in 1 2 3; do west sdk install --install-base /mnt -t arm-zephyr-eabi --personal-access-token "${GITHUB_TOKEN}" && break || sleep 5; done
 
       - name: Build and run test
         env:
@@ -250,7 +256,13 @@ jobs:
           west init -m https://github.com/pulseengine/zephyr.git --mr gale/sem-replacement /mnt/zephyr-workspace
           cd /mnt/zephyr-workspace
           west update --narrow -o=--depth=1
-          for attempt in 1 2 3; do west sdk install -t arm-zephyr-eabi --personal-access-token "${GITHUB_TOKEN}" && break || sleep 5; done
+          # --install-base /mnt: extract the SDK onto the big ephemeral disk, not
+          # $HOME (=/root) on the small host fs. The default home-dir extract
+          # tips the runner into ENOSPC (writing its own diag log) during the
+          # zephyr-sdk download — the residual gale#73 vector left after the
+          # workspace was moved to /mnt. The CMake package registry still finds
+          # the SDK regardless of install location.
+          for attempt in 1 2 3; do west sdk install --install-base /mnt -t arm-zephyr-eabi --personal-access-token "${GITHUB_TOKEN}" && break || sleep 5; done
 
       - name: Build and run test
         env:
@@ -350,7 +362,8 @@ jobs:
           west init -m https://github.com/pulseengine/zephyr.git --mr gale/sem-replacement /mnt/zephyr-workspace
           cd /mnt/zephyr-workspace
           west update --narrow -o=--depth=1
-          for attempt in 1 2 3; do west sdk install -t x86_64-zephyr-elf --personal-access-token "${GITHUB_TOKEN}" && break || sleep 5; done
+          # --install-base /mnt: SDK onto the big disk, not /root (gale#73 ENOSPC). See arm jobs above.
+          for attempt in 1 2 3; do west sdk install --install-base /mnt -t x86_64-zephyr-elf --personal-access-token "${GITHUB_TOKEN}" && break || sleep 5; done
 
       - name: Build and run test
         env:
@@ -411,7 +424,13 @@ jobs:
           west init -m https://github.com/pulseengine/zephyr.git --mr gale/sem-replacement /mnt/zephyr-workspace
           cd /mnt/zephyr-workspace
           west update --narrow -o=--depth=1
-          for attempt in 1 2 3; do west sdk install -t arm-zephyr-eabi --personal-access-token "${GITHUB_TOKEN}" && break || sleep 5; done
+          # --install-base /mnt: extract the SDK onto the big ephemeral disk, not
+          # $HOME (=/root) on the small host fs. The default home-dir extract
+          # tips the runner into ENOSPC (writing its own diag log) during the
+          # zephyr-sdk download — the residual gale#73 vector left after the
+          # workspace was moved to /mnt. The CMake package registry still finds
+          # the SDK regardless of install location.
+          for attempt in 1 2 3; do west sdk install --install-base /mnt -t arm-zephyr-eabi --personal-access-token "${GITHUB_TOKEN}" && break || sleep 5; done
 
       - name: Setup SDK paths
         run: |

--- a/.github/workflows/zephyr-tests.yml
+++ b/.github/workflows/zephyr-tests.yml
@@ -434,7 +434,13 @@ jobs:
 
       - name: Setup SDK paths
         run: |
-          SDK_DIR=$(find /root -maxdepth 1 -name 'zephyr-sdk-*' -type d 2>/dev/null | head -1)
+          # The SDK now extracts to /mnt (--install-base /mnt, see the install step);
+          # search there first, then the legacy $HOME (/root) and /opt locations.
+          # The build itself finds the SDK via the CMake package registry regardless,
+          # but this job also invokes arm-zephyr-eabi-size by bare name, so its bin
+          # must be on PATH from wherever the SDK actually landed.
+          SDK_DIR=$(find /mnt -maxdepth 1 -name 'zephyr-sdk-*' -type d 2>/dev/null | head -1)
+          [ -z "${SDK_DIR}" ] && SDK_DIR=$(find /root -maxdepth 1 -name 'zephyr-sdk-*' -type d 2>/dev/null | head -1)
           [ -z "${SDK_DIR}" ] && SDK_DIR=$(find /opt -maxdepth 2 -name 'zephyr-sdk-*' -type d 2>/dev/null | head -1)
           # SDK 1.0+ added a 'gnu' subdirectory under the SDK root for the GNU toolchain;
           # older layouts had the arm-zephyr-eabi directly under the SDK root.

--- a/.github/workflows/zephyr-tests.yml
+++ b/.github/workflows/zephyr-tests.yml
@@ -24,6 +24,14 @@ concurrency:
 env:
   HOME: /root
   DOCKER_CONFIG: /tmp/.docker
+  # Store rustup toolchains (incl. the large rust-std component) on the big
+  # ephemeral disk, not /root. Symptom that motivated this: jobs intermittently
+  # died mid `rustup` at "downloading component rust-std" with no error and an
+  # empty step list — the disk-full signature (the runner can't even write the
+  # error), same /root-exhaustion class as the SDK extract (gale#73). rustup
+  # reads RUSTUP_HOME for toolchain storage; CARGO_HOME stays default (/root/.cargo)
+  # so the proxies + `. /root/.cargo/env` sourcing in the build steps are unchanged.
+  RUSTUP_HOME: /mnt/.rustup
   # Token value for `west sdk install --personal-access-token` (see the install
   # steps). `west sdk install`'s "Fetching Zephyr SDK list" hits the GitHub API;
   # anonymous = 60 req/hr per runner IP, and with ~59 concurrent jobs that limit


### PR DESCRIPTION
## The residual ENOSPC vector

#92 moved the west **workspace** to `/mnt`, but `west sdk install` still extracts the `zephyr-sdk` to `$HOME` (=`/root`) on the small host fs (~14 GB free under the ci-base layers). The SDK download/unpack tips the runner into **ENOSPC** — just observed failing `event` + `sys_event` (qemu_cortex_m3) on PR#97 with `No space left on device` while the runner wrote its own `_diag` log, mid `west sdk install`. Unrelated to the PR's code; it's the residual gale#73 vector after the workspace move.

## Fix
`--install-base /mnt` on all four `zephyr-tests.yml` SDK installs (cortex_m3, mps2, x86_64-SMP, userspace — all already mount `--volume /mnt:/mnt`). The SDK extracts onto the ~70 GB ephemeral disk instead of `/root`. The CMake package registry (`~/.cmake/packages/Zephyr-sdk`) records the SDK regardless of install path, so the build finds it unchanged.

Flag verified against the pulseengine/zephyr fork's `scripts/west_commands/sdk.py` (`--install-base BASE`; default extract dir is `$HOME`).

Refs gale#73.

🤖 Generated with [Claude Code](https://claude.com/claude-code)